### PR TITLE
Refactor: 주문 배치 정합성과 Testcontainers 실행 규칙 정리

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# Repository Guidelines
+
+## 프로젝트 구조 및 모듈 책임
+`happyGallery`는 멀티 모듈 Gradle 프로젝트다. `app/`에는 Spring Boot 진입점, 컨트롤러, 애플리케이션 서비스, 배치 작업, 통합 테스트가 있다. `domain/`은 엔티티와 정책처럼 핵심 비즈니스 규칙을 둔다. `infra/`는 JPA 리포지토리, 결제, 알림 등 외부 연동 구현을 담당한다. `common/`은 공통 예외와 시간 유틸리티를 둔다. 기능을 추가할 때는 먼저 레이어 책임에 맞는 모듈을 고르고, `app`에서 도메인 규칙을 직접 구현하거나 `infra`에 업무 규칙을 넣지 않는다.
+
+## 빌드, 테스트, 개발 명령어
+모든 명령은 저장소 루트에서 Gradle Wrapper로 실행한다.
+
+- `./gradlew build`: 전체 모듈 컴파일과 전체 테스트 실행
+- `./gradlew test`: 산출물 생성 없이 전체 테스트만 실행
+- `./gradlew :app:bootRun`: 로컬 API 실행
+- `./gradlew :app:useCaseTest`: `@Tag("usecase")` 통합 테스트 실행
+- `./gradlew :app:policyTest`: `policy` 태그가 붙은 정책 테스트 실행
+- `docker compose up -d`: 로컬 MySQL 등 의존 서비스 실행
+
+Testcontainers를 사용하는 테스트(`:app:useCaseTest`, `@UseCaseIT`, 특정 `--tests` 대상 실행 포함)는 Docker 탐지 실패를 피하기 위해 기본적으로 `./gradlew --no-daemon ...` 형태로 실행한다.
+
+기본 프로필은 `local`이며, 헬스 체크는 `http://localhost:8080/actuator/health`에서 확인한다.
+
+## 코딩 스타일 및 네이밍 규칙
+Java 21과 Gradle toolchain 설정을 따른다. 패키지는 `com.personal.happygallery.<layer>.<feature>` 구조를 유지한다. 들여쓰기는 공백 4칸을 사용하고, 클래스는 `UpperCamelCase`, 메서드와 필드는 `lowerCamelCase`를 사용한다. 엔티티와 값 객체는 단수형 이름을 사용한다. 컨트롤러는 요청 검증과 응답 변환에 집중하고, 비즈니스 흐름은 서비스로, 정책 판단은 도메인 객체나 정책 클래스로 분리한다. DTO는 `Request`, `Response` 접미사를 명확히 붙인다.
+
+## 테스트 작성 기준
+테스트 프레임워크는 JUnit 5다. 정책이나 경계 조건 검증은 `*PolicyTest`로 작성하고 `policy` 태그를 사용한다. Spring Boot 컨텍스트, Flyway, Testcontainers(MySQL)를 함께 검증하는 흐름은 `@UseCaseIT`와 `*UseCaseIT` 형식으로 작성한다. 동작을 바꾸면 관련 테스트를 같이 수정하는 것을 기본으로 한다. 빠른 규칙 검증은 정책 테스트에, 트랜잭션·연동·동시성 검증은 통합 테스트에 둔다.
+
+코드를 수정한 뒤에는 관련 테스트를 반드시 실행한다. 실패하면 원인을 수정한 뒤 성공할 때까지 다시 검증한다. 테스트는 항상 변경 범위에 맞는 최소 단위부터 선택한다. 정책이나 도메인 규칙만 바뀌면 `./gradlew :app:policyTest`를 우선 실행하고, 유스케이스 흐름이나 DB·외부 연동 영향이 있으면 `./gradlew :app:useCaseTest`까지 실행한다. 전체 안정성 확인이 필요한 큰 변경에서만 `./gradlew test` 또는 `./gradlew build`를 사용한다.
+Testcontainers 기반 검증은 위 원칙과 별개로 `--no-daemon`을 유지한다.
+
+## DB 및 설정 변경 규칙
+DB 스키마 변경은 `app/src/main/resources/db/migration` 아래 Flyway 스크립트로만 반영한다. 파일명은 기존처럼 `V6__description.sql` 형식을 따른다. 환경별 설정은 `app/src/main/resources/application-*.yml`에 두고, 기본 프로필과 공통 설정은 `application.yml`에서 관리한다. `ADMIN_API_KEY`, DB 접속 정보 등 비밀값은 환경 변수로 주입하고 저장소에 하드코딩하지 않는다.
+
+## 문서 작성 규칙
+문서는 `docs` 아래를 문서 성격별 카테고리로 나눠 관리한다. 새 문서는 `docs/<Category>/0001_<topic>` 형식의 번호 기반 폴더를 만든 뒤 추가한다.
+
+현재 프로젝트의 기준 스펙 문서는 `docs/PRD/0001_spec/spec.md`다. 구현, 테스트, 상태값, API 계약, 시간 경계 조건은 이 문서를 우선 기준으로 따르고, 요구사항 변경 시 `spec.md`와 구현을 함께 갱신한다.
+
+- `docs/Idea`: 아이디어 스케치, 문제 정의, 초기 방향 정리
+- `docs/1Pager`: 이해관계자 공유용 한 장 요약 문서
+- `docs/PRD`: 기능 요구사항, 정책, API/화면, 비기능 요구사항 상세
+- `docs/POC`: 실험 가설, 검증 방법, 결과, 결론 기록
+- `docs/ADR`: 기술적·제품적 의사결정과 근거 기록
+
+설계 판단이 바뀌면 ADR을 먼저 검토하고, 요구사항이 바뀌면 PRD와 구현을 함께 갱신한다.
+
+## 커밋 및 Pull Request 가이드
+최근 커밋 메시지는 `Feat:`, `Refactor:`, `Test:` 같은 타입 접두사 뒤에 짧은 설명을 붙이는 형식이다. 필요하면 `§12.1` 같은 스펙 참조를 추가한다. 커밋은 하나의 변경 의도에 집중해 작게 유지한다. 코드를 작성하거나 수정한 작업은 관련 테스트 검증까지 마친 뒤 Pull Request 생성까지 완료하는 것을 기본으로 한다. 작업은 `codex/work-*` 같은 작업 브랜치에서 시작하고, 먼저 `codexReview`를 대상으로 Draft PR을 올려 리뷰와 통합 확인을 진행한다. 작업 완료 후에는 `codexReview`로 머지하고, `codexReview`에서 문제가 없을 때만 `main` 대상으로 최종 PR을 생성해 머지한다. PR 제목은 변경 내용을 한 줄로 요약하고, 본문은 저장소의 PR 템플릿을 사용해 주요 변경 사항을 리스트로 작성한다. Pull Request에는 해결하려는 문제, 핵심 설계 판단, 실행한 테스트 명령, API 변경 시 예시 요청·응답이나 화면 변경 자료를 포함한다.

--- a/app/src/main/java/com/personal/happygallery/app/batch/BatchScheduler.java
+++ b/app/src/main/java/com/personal/happygallery/app/batch/BatchScheduler.java
@@ -43,7 +43,7 @@ public class BatchScheduler {
     }
 
     /** 주문 승인 SLA(24h) 초과 → 자동환불. 매시간 정각 실행. */
-    @Scheduled(cron = "0 0 * * * *")
+    @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
     public void runOrderAutoRefund() {
         log.info("[배치] 주문 자동환불 시작");
         int count = orderAutoRefundBatchService.autoRefundExpired();
@@ -51,7 +51,7 @@ public class BatchScheduler {
     }
 
     /** 픽업 마감 초과 → 자동취소·환불. 매시간 정각 실행. */
-    @Scheduled(cron = "0 0 * * * *")
+    @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
     public void runPickupExpire() {
         log.info("[배치] 픽업 만료 시작");
         int count = pickupExpireBatchService.expirePickups();
@@ -59,7 +59,7 @@ public class BatchScheduler {
     }
 
     /** 만료된 8회권 크레딧 소멸. 매일 00:00 실행. */
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     public void runPassExpiry() {
         log.info("[배치] 8회권 크레딧 소멸 시작");
         int count = passExpiryBatchService.expireAll();
@@ -67,7 +67,7 @@ public class BatchScheduler {
     }
 
     /** 8회권 만료 7일 전 알림. 매일 09:00 실행. */
-    @Scheduled(cron = "0 0 9 * * *")
+    @Scheduled(cron = "0 0 9 * * *", zone = "Asia/Seoul")
     public void runPassExpiryNotification() {
         log.info("[배치] 8회권 만료 7일 전 알림 시작");
         int count = passExpiryBatchService.sendExpiryNotifications();
@@ -75,7 +75,7 @@ public class BatchScheduler {
     }
 
     /** 예약 D-1 리마인드. 매일 00:00 실행. */
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     public void runBookingD1Reminder() {
         log.info("[배치] D-1 예약 리마인드 시작");
         int count = bookingReminderBatchService.sendD1Reminders();
@@ -83,7 +83,7 @@ public class BatchScheduler {
     }
 
     /** 예약 당일 리마인드. 매일 07:00 실행. */
-    @Scheduled(cron = "0 0 7 * * *")
+    @Scheduled(cron = "0 0 7 * * *", zone = "Asia/Seoul")
     public void runBookingSameDayReminder() {
         log.info("[배치] 당일 예약 리마인드 시작");
         int count = bookingReminderBatchService.sendSameDayReminders();

--- a/app/src/main/java/com/personal/happygallery/app/order/OrderApprovalService.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/OrderApprovalService.java
@@ -5,6 +5,8 @@ import com.personal.happygallery.app.product.InventoryService;
 import com.personal.happygallery.common.error.NotFoundException;
 import com.personal.happygallery.domain.notification.NotificationEventType;
 import com.personal.happygallery.domain.booking.Refund;
+import com.personal.happygallery.domain.order.OrderApprovalDecision;
+import com.personal.happygallery.domain.order.OrderApprovalHistory;
 import com.personal.happygallery.domain.order.Fulfillment;
 import com.personal.happygallery.domain.order.FulfillmentType;
 import com.personal.happygallery.domain.order.Order;
@@ -14,6 +16,7 @@ import com.personal.happygallery.domain.product.Product;
 import com.personal.happygallery.domain.product.ProductType;
 import com.personal.happygallery.infra.booking.RefundRepository;
 import com.personal.happygallery.infra.order.FulfillmentRepository;
+import com.personal.happygallery.infra.order.OrderApprovalHistoryRepository;
 import com.personal.happygallery.infra.order.OrderItemRepository;
 import com.personal.happygallery.infra.order.OrderRepository;
 import com.personal.happygallery.infra.payment.PaymentProvider;
@@ -49,6 +52,7 @@ public class OrderApprovalService {
     private final PaymentProvider paymentProvider;
     private final ProductRepository productRepository;
     private final FulfillmentRepository fulfillmentRepository;
+    private final OrderApprovalHistoryRepository orderApprovalHistoryRepository;
     private final NotificationService notificationService;
 
     public OrderApprovalService(OrderRepository orderRepository,
@@ -58,6 +62,7 @@ public class OrderApprovalService {
                                 PaymentProvider paymentProvider,
                                 ProductRepository productRepository,
                                 FulfillmentRepository fulfillmentRepository,
+                                OrderApprovalHistoryRepository orderApprovalHistoryRepository,
                                 NotificationService notificationService) {
         this.orderRepository = orderRepository;
         this.orderItemRepository = orderItemRepository;
@@ -66,6 +71,7 @@ public class OrderApprovalService {
         this.paymentProvider = paymentProvider;
         this.productRepository = productRepository;
         this.fulfillmentRepository = fulfillmentRepository;
+        this.orderApprovalHistoryRepository = orderApprovalHistoryRepository;
         this.notificationService = notificationService;
     }
 
@@ -80,7 +86,7 @@ public class OrderApprovalService {
      * @return 승인된 주문
      */
     public Order approve(Long orderId) {
-        Order order = orderRepository.findById(orderId)
+        Order order = orderRepository.findByIdWithLock(orderId)
                 .orElseThrow(() -> new NotFoundException("주문"));
 
         boolean isMadeToOrder = isMadeToOrderOrder(order);
@@ -91,6 +97,7 @@ public class OrderApprovalService {
         } else {
             order.approve();
         }
+        orderApprovalHistoryRepository.save(new OrderApprovalHistory(order.getId(), OrderApprovalDecision.APPROVE));
         return orderRepository.save(order);
     }
 
@@ -119,12 +126,13 @@ public class OrderApprovalService {
      * @return 거절된 주문
      */
     public Order reject(Long orderId) {
-        Order order = orderRepository.findById(orderId)
+        Order order = orderRepository.findByIdWithLock(orderId)
                 .orElseThrow(() -> new NotFoundException("주문"));
         order.reject();
 
         restoreInventory(order);
         processRefund(order);
+        orderApprovalHistoryRepository.save(new OrderApprovalHistory(order.getId(), OrderApprovalDecision.REJECT));
         notificationService.notifyByGuestId(order.getGuestId(), NotificationEventType.ORDER_REFUNDED);
 
         return orderRepository.save(order);

--- a/app/src/main/java/com/personal/happygallery/app/order/OrderAutoRefundBatchService.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/OrderAutoRefundBatchService.java
@@ -57,17 +57,27 @@ public class OrderAutoRefundBatchService {
         LocalDateTime now = LocalDateTime.now(clock);
         List<Order> expired = orderRepository.findByStatusAndApprovalDeadlineAtBefore(
                 OrderStatus.PAID_APPROVAL_PENDING, now);
+        int processed = 0;
 
-        for (Order order : expired) {
+        for (Order candidate : expired) {
+            Order order = orderRepository.findByIdWithLock(candidate.getId())
+                    .orElseThrow(() -> new IllegalStateException("주문이 사라졌습니다. id=" + candidate.getId()));
+            if (order.getStatus() != OrderStatus.PAID_APPROVAL_PENDING) {
+                continue;
+            }
+            if (order.getApprovalDeadlineAt() == null || !order.getApprovalDeadlineAt().isBefore(now)) {
+                continue;
+            }
             orderApprovalService.restoreInventory(order);
             orderApprovalService.processRefund(order);
             order.markAutoRefunded();
             orderRepository.save(order);
             notificationService.notifyByGuestId(order.getGuestId(), NotificationEventType.ORDER_REFUNDED);
             log.info("주문 자동환불 처리 [orderId={}]", order.getId());
+            processed++;
         }
 
-        log.info("자동환불 배치 완료: {}건 처리", expired.size());
-        return expired.size();
+        log.info("자동환불 배치 완료: {}건 처리", processed);
+        return processed;
     }
 }

--- a/app/src/main/java/com/personal/happygallery/app/order/OrderPickupService.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/OrderPickupService.java
@@ -40,7 +40,7 @@ public class OrderPickupService {
      * @return 픽업 결과 (주문 ID, 상태, 마감 시각)
      */
     public PickupResult markPickupReady(Long orderId, LocalDateTime pickupDeadlineAt) {
-        Order order = orderRepository.findById(orderId)
+        Order order = orderRepository.findByIdWithLock(orderId)
                 .orElseThrow(() -> new NotFoundException("주문"));
         order.markPickupReady();
 
@@ -58,11 +58,11 @@ public class OrderPickupService {
      * @return 픽업 결과 (주문 ID, 상태, 마감 시각)
      */
     public PickupResult confirmPickup(Long orderId) {
-        Order order = orderRepository.findById(orderId)
+        Order order = orderRepository.findByIdWithLock(orderId)
                 .orElseThrow(() -> new NotFoundException("주문"));
         order.confirmPickup();
 
-        Fulfillment fulfillment = fulfillmentRepository.findByOrderId(orderId)
+        Fulfillment fulfillment = fulfillmentRepository.findByOrderIdWithLock(orderId)
                 .orElseThrow(() -> new NotFoundException("이행 정보"));
         fulfillment.syncStatus(order.getStatus());
         fulfillmentRepository.save(fulfillment);

--- a/app/src/main/java/com/personal/happygallery/app/order/OrderProductionService.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/OrderProductionService.java
@@ -1,9 +1,12 @@
 package com.personal.happygallery.app.order;
 
 import com.personal.happygallery.common.error.NotFoundException;
+import com.personal.happygallery.domain.order.OrderApprovalDecision;
+import com.personal.happygallery.domain.order.OrderApprovalHistory;
 import com.personal.happygallery.domain.order.Fulfillment;
 import com.personal.happygallery.domain.order.Order;
 import com.personal.happygallery.domain.order.OrderStatus;
+import com.personal.happygallery.infra.order.OrderApprovalHistoryRepository;
 import com.personal.happygallery.infra.order.FulfillmentRepository;
 import com.personal.happygallery.infra.order.OrderRepository;
 import java.time.LocalDate;
@@ -27,11 +30,14 @@ public class OrderProductionService {
 
     private final OrderRepository orderRepository;
     private final FulfillmentRepository fulfillmentRepository;
+    private final OrderApprovalHistoryRepository orderApprovalHistoryRepository;
 
     public OrderProductionService(OrderRepository orderRepository,
-                                  FulfillmentRepository fulfillmentRepository) {
+                                  FulfillmentRepository fulfillmentRepository,
+                                  OrderApprovalHistoryRepository orderApprovalHistoryRepository) {
         this.orderRepository = orderRepository;
         this.fulfillmentRepository = fulfillmentRepository;
+        this.orderApprovalHistoryRepository = orderApprovalHistoryRepository;
     }
 
     /**
@@ -42,9 +48,9 @@ public class OrderProductionService {
      * @return 주문 상태 + 갱신된 출고일
      */
     public ProductionResult setExpectedShipDate(Long orderId, LocalDate expectedShipDate) {
-        Order order = orderRepository.findById(orderId)
+        Order order = orderRepository.findByIdWithLock(orderId)
                 .orElseThrow(() -> new NotFoundException("주문"));
-        Fulfillment fulfillment = fulfillmentRepository.findByOrderId(orderId)
+        Fulfillment fulfillment = fulfillmentRepository.findByOrderIdWithLock(orderId)
                 .orElseThrow(() -> new NotFoundException("이행 정보"));
 
         fulfillment.setExpectedShipDate(expectedShipDate);
@@ -61,15 +67,16 @@ public class OrderProductionService {
      * @return 전이된 주문 상태 + 출고일
      */
     public ProductionResult requestDelay(Long orderId) {
-        Order order = orderRepository.findById(orderId)
+        Order order = orderRepository.findByIdWithLock(orderId)
                 .orElseThrow(() -> new NotFoundException("주문"));
         order.requestDelay();
 
-        Fulfillment fulfillment = fulfillmentRepository.findByOrderId(orderId)
+        Fulfillment fulfillment = fulfillmentRepository.findByOrderIdWithLock(orderId)
                 .orElseThrow(() -> new NotFoundException("이행 정보"));
         fulfillment.syncStatus(order.getStatus());
         fulfillmentRepository.save(fulfillment);
 
+        orderApprovalHistoryRepository.save(new OrderApprovalHistory(order.getId(), OrderApprovalDecision.DELAY));
         orderRepository.save(order);
         return new ProductionResult(order.getId(), order.getStatus(), fulfillment.getExpectedShipDate());
     }

--- a/app/src/main/java/com/personal/happygallery/app/order/PickupExpireBatchService.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/PickupExpireBatchService.java
@@ -58,10 +58,23 @@ public class PickupExpireBatchService {
         LocalDateTime now = LocalDateTime.now(clock);
         List<Fulfillment> expired = fulfillmentRepository
                 .findByStatusAndPickupDeadlineAtBefore(OrderStatus.PICKUP_READY, now);
+        int processed = 0;
 
-        for (Fulfillment fulfillment : expired) {
-            Order order = orderRepository.findById(fulfillment.getOrderId())
+        for (Fulfillment candidate : expired) {
+            Fulfillment fulfillment = fulfillmentRepository.findByOrderIdWithLock(candidate.getOrderId())
+                    .orElseThrow(() -> new NotFoundException("이행 정보"));
+            if (fulfillment.getStatus() != OrderStatus.PICKUP_READY) {
+                continue;
+            }
+            if (fulfillment.getPickupDeadlineAt() == null || !fulfillment.getPickupDeadlineAt().isBefore(now)) {
+                continue;
+            }
+
+            Order order = orderRepository.findByIdWithLock(fulfillment.getOrderId())
                     .orElseThrow(() -> new NotFoundException("주문"));
+            if (order.getStatus() != OrderStatus.PICKUP_READY) {
+                continue;
+            }
 
             orderApprovalService.restoreInventory(order);
             orderApprovalService.processRefund(order);
@@ -71,9 +84,10 @@ public class PickupExpireBatchService {
             orderRepository.save(order);
             fulfillmentRepository.save(fulfillment);
             log.info("픽업 만료 처리 [orderId={}, fulfillmentId={}]", order.getId(), fulfillment.getId());
+            processed++;
         }
 
-        log.info("픽업 만료 배치 완료: {}건 처리", expired.size());
-        return expired.size();
+        log.info("픽업 만료 배치 완료: {}건 처리", processed);
+        return processed;
     }
 }

--- a/app/src/main/java/com/personal/happygallery/app/pass/PassExpiryBatchService.java
+++ b/app/src/main/java/com/personal/happygallery/app/pass/PassExpiryBatchService.java
@@ -5,6 +5,7 @@ import com.personal.happygallery.domain.notification.NotificationEventType;
 import com.personal.happygallery.domain.pass.PassLedger;
 import com.personal.happygallery.domain.pass.PassLedgerType;
 import com.personal.happygallery.domain.pass.PassPurchase;
+import com.personal.happygallery.infra.notification.NotificationLogRepository;
 import com.personal.happygallery.infra.pass.PassLedgerRepository;
 import com.personal.happygallery.infra.pass.PassPurchaseRepository;
 import java.time.Clock;
@@ -23,15 +24,18 @@ public class PassExpiryBatchService {
 
     private final PassPurchaseRepository passPurchaseRepository;
     private final PassLedgerRepository passLedgerRepository;
+    private final NotificationLogRepository notificationLogRepository;
     private final NotificationService notificationService;
     private final Clock clock;
 
     public PassExpiryBatchService(PassPurchaseRepository passPurchaseRepository,
                                   PassLedgerRepository passLedgerRepository,
+                                  NotificationLogRepository notificationLogRepository,
                                   NotificationService notificationService,
                                   Clock clock) {
         this.passPurchaseRepository = passPurchaseRepository;
         this.passLedgerRepository = passLedgerRepository;
+        this.notificationLogRepository = notificationLogRepository;
         this.notificationService = notificationService;
         this.clock = clock;
     }
@@ -70,9 +74,10 @@ public class PassExpiryBatchService {
     @Transactional(readOnly = true)
     public List<PassPurchase> findExpiringWithin7Days() {
         LocalDateTime now = LocalDateTime.now(clock);
-        LocalDateTime in7Days = now.plusDays(7);
+        LocalDateTime targetStart = now.plusDays(7).toLocalDate().atStartOfDay();
+        LocalDateTime targetEnd = targetStart.plusDays(1);
         return passPurchaseRepository
-                .findByExpiresAtBetweenAndRemainingCreditsGreaterThan(now, in7Days, 0);
+                .findByExpiresAtBetweenAndRemainingCreditsGreaterThan(targetStart, targetEnd, 0);
     }
 
     /**
@@ -84,15 +89,28 @@ public class PassExpiryBatchService {
      */
     public int sendExpiryNotifications() {
         LocalDateTime now = LocalDateTime.now(clock);
-        LocalDateTime in7Days = now.plusDays(7);
-        List<PassPurchase> expiring = passPurchaseRepository.findExpiringWithGuestBetween(now, in7Days);
+        LocalDateTime targetStart = now.plusDays(7).toLocalDate().atStartOfDay();
+        LocalDateTime targetEnd = targetStart.plusDays(1);
+        LocalDateTime sentStart = now.toLocalDate().atStartOfDay();
+        LocalDateTime sentEnd = sentStart.plusDays(1);
+        List<PassPurchase> expiring = passPurchaseRepository.findExpiringWithGuestBetween(targetStart, targetEnd);
+        int notified = 0;
 
         for (PassPurchase pass : expiring) {
+            if (notificationLogRepository.existsByGuestIdAndEventTypeAndStatusAndSentAtBetween(
+                    pass.getGuest().getId(),
+                    NotificationEventType.PASS_EXPIRY_SOON,
+                    "SUCCESS",
+                    sentStart,
+                    sentEnd)) {
+                continue;
+            }
             notificationService.notifyByGuestId(pass.getGuest().getId(), NotificationEventType.PASS_EXPIRY_SOON);
             log.info("8회권 만료 7일 전 알림 발송 [passId={}, guestId={}]", pass.getId(), pass.getGuest().getId());
+            notified++;
         }
 
-        log.info("8회권 만료 7일 전 알림 배치 완료: {}건", expiring.size());
-        return expiring.size();
+        log.info("8회권 만료 7일 전 알림 배치 완료: {}건", notified);
+        return notified;
     }
 }

--- a/app/src/test/java/com/personal/happygallery/app/order/ConcurrentOrderUseCaseIT.java
+++ b/app/src/test/java/com/personal/happygallery/app/order/ConcurrentOrderUseCaseIT.java
@@ -7,6 +7,7 @@ import com.personal.happygallery.domain.product.ProductType;
 import com.personal.happygallery.infra.booking.RefundRepository;
 import com.personal.happygallery.infra.order.FulfillmentRepository;
 import com.personal.happygallery.infra.order.OrderItemRepository;
+import com.personal.happygallery.infra.order.OrderApprovalHistoryRepository;
 import com.personal.happygallery.infra.order.OrderRepository;
 import com.personal.happygallery.infra.product.InventoryRepository;
 import com.personal.happygallery.infra.product.ProductRepository;
@@ -36,6 +37,7 @@ class ConcurrentOrderUseCaseIT {
     @Autowired OrderService orderService;
     @Autowired OrderRepository orderRepository;
     @Autowired OrderItemRepository orderItemRepository;
+    @Autowired OrderApprovalHistoryRepository orderApprovalHistoryRepository;
     @Autowired FulfillmentRepository fulfillmentRepository;
     @Autowired RefundRepository refundRepository;
     @Autowired ProductRepository productRepository;
@@ -54,6 +56,7 @@ class ConcurrentOrderUseCaseIT {
     private void cleanup() {
         refundRepository.deleteAll();
         fulfillmentRepository.deleteAll();
+        orderApprovalHistoryRepository.deleteAll();
         orderItemRepository.deleteAll();
         orderRepository.deleteAll();
         inventoryRepository.deleteAll();

--- a/app/src/test/java/com/personal/happygallery/app/order/OrderApprovalUseCaseIT.java
+++ b/app/src/test/java/com/personal/happygallery/app/order/OrderApprovalUseCaseIT.java
@@ -2,6 +2,7 @@ package com.personal.happygallery.app.order;
 
 import com.personal.happygallery.common.error.AlreadyRefundedException;
 import com.personal.happygallery.domain.order.Order;
+import com.personal.happygallery.domain.order.OrderApprovalDecision;
 import com.personal.happygallery.domain.order.OrderItem;
 import com.personal.happygallery.domain.order.OrderStatus;
 import com.personal.happygallery.domain.product.Inventory;
@@ -9,6 +10,7 @@ import com.personal.happygallery.domain.product.Product;
 import com.personal.happygallery.domain.product.ProductType;
 import com.personal.happygallery.infra.booking.RefundRepository;
 import com.personal.happygallery.infra.order.OrderItemRepository;
+import com.personal.happygallery.infra.order.OrderApprovalHistoryRepository;
 import com.personal.happygallery.infra.order.OrderRepository;
 import com.personal.happygallery.infra.product.InventoryRepository;
 import com.personal.happygallery.infra.product.ProductRepository;
@@ -39,6 +41,7 @@ class OrderApprovalUseCaseIT {
     @Autowired WebApplicationContext context;
     @Autowired OrderRepository orderRepository;
     @Autowired OrderItemRepository orderItemRepository;
+    @Autowired OrderApprovalHistoryRepository orderApprovalHistoryRepository;
     @Autowired RefundRepository refundRepository;
     @Autowired ProductRepository productRepository;
     @Autowired InventoryRepository inventoryRepository;
@@ -63,6 +66,7 @@ class OrderApprovalUseCaseIT {
     private void cleanup() {
         // FK 삭제 순서: refunds(order_id) → order_items → orders → inventory → products
         refundRepository.deleteAll();
+        orderApprovalHistoryRepository.deleteAll();
         orderItemRepository.deleteAll();
         orderRepository.deleteAll();
         inventoryRepository.deleteAll();
@@ -86,6 +90,9 @@ class OrderApprovalUseCaseIT {
 
         Order updated = orderRepository.findById(order.getId()).orElseThrow();
         assertThat(updated.getStatus()).isEqualTo(OrderStatus.APPROVED_FULFILLMENT_PENDING);
+        assertThat(orderApprovalHistoryRepository.findByOrderId(order.getId()))
+                .extracting("decision")
+                .containsExactly(OrderApprovalDecision.APPROVE);
     }
 
     // -----------------------------------------------------------------------
@@ -109,6 +116,9 @@ class OrderApprovalUseCaseIT {
         // 주문 상태 확인
         Order updated = orderRepository.findById(order.getId()).orElseThrow();
         assertThat(updated.getStatus()).isEqualTo(OrderStatus.REJECTED_REFUNDED);
+        assertThat(orderApprovalHistoryRepository.findByOrderId(order.getId()))
+                .extracting("decision")
+                .containsExactly(OrderApprovalDecision.REJECT);
 
         // 재고 복구 확인
         assertThat(inventoryRepository.findByProductId(product.getId()).orElseThrow().getQuantity()).isEqualTo(1);

--- a/app/src/test/java/com/personal/happygallery/app/order/OrderProductionUseCaseIT.java
+++ b/app/src/test/java/com/personal/happygallery/app/order/OrderProductionUseCaseIT.java
@@ -3,6 +3,7 @@ package com.personal.happygallery.app.order;
 import com.personal.happygallery.common.error.ProductionRefundNotAllowedException;
 import com.personal.happygallery.domain.order.Fulfillment;
 import com.personal.happygallery.domain.order.Order;
+import com.personal.happygallery.domain.order.OrderApprovalDecision;
 import com.personal.happygallery.domain.order.OrderStatus;
 import com.personal.happygallery.domain.product.Inventory;
 import com.personal.happygallery.domain.product.Product;
@@ -10,6 +11,7 @@ import com.personal.happygallery.domain.product.ProductType;
 import com.personal.happygallery.infra.booking.RefundRepository;
 import com.personal.happygallery.infra.order.FulfillmentRepository;
 import com.personal.happygallery.infra.order.OrderItemRepository;
+import com.personal.happygallery.infra.order.OrderApprovalHistoryRepository;
 import com.personal.happygallery.infra.order.OrderRepository;
 import com.personal.happygallery.infra.product.InventoryRepository;
 import com.personal.happygallery.infra.product.ProductRepository;
@@ -37,6 +39,7 @@ class OrderProductionUseCaseIT {
     @Autowired WebApplicationContext context;
     @Autowired OrderRepository orderRepository;
     @Autowired OrderItemRepository orderItemRepository;
+    @Autowired OrderApprovalHistoryRepository orderApprovalHistoryRepository;
     @Autowired FulfillmentRepository fulfillmentRepository;
     @Autowired RefundRepository refundRepository;
     @Autowired ProductRepository productRepository;
@@ -61,6 +64,7 @@ class OrderProductionUseCaseIT {
     private void cleanup() {
         refundRepository.deleteAll();
         fulfillmentRepository.deleteAll();
+        orderApprovalHistoryRepository.deleteAll();
         orderItemRepository.deleteAll();
         orderRepository.deleteAll();
         inventoryRepository.deleteAll();
@@ -152,6 +156,9 @@ class OrderProductionUseCaseIT {
 
         Fulfillment fulfillment = fulfillmentRepository.findByOrderId(order.getId()).orElseThrow();
         assertThat(fulfillment.getStatus()).isEqualTo(OrderStatus.DELAY_REQUESTED);
+        assertThat(orderApprovalHistoryRepository.findByOrderId(order.getId()))
+                .extracting("decision")
+                .containsExactly(OrderApprovalDecision.APPROVE, OrderApprovalDecision.DELAY);
     }
 
     // -----------------------------------------------------------------------

--- a/app/src/test/java/com/personal/happygallery/app/order/PickupExpireBatchUseCaseIT.java
+++ b/app/src/test/java/com/personal/happygallery/app/order/PickupExpireBatchUseCaseIT.java
@@ -10,6 +10,7 @@ import com.personal.happygallery.domain.product.ProductType;
 import com.personal.happygallery.infra.booking.RefundRepository;
 import com.personal.happygallery.infra.order.FulfillmentRepository;
 import com.personal.happygallery.infra.order.OrderItemRepository;
+import com.personal.happygallery.infra.order.OrderApprovalHistoryRepository;
 import com.personal.happygallery.infra.order.OrderRepository;
 import com.personal.happygallery.infra.product.InventoryRepository;
 import com.personal.happygallery.infra.product.ProductRepository;
@@ -37,6 +38,7 @@ class PickupExpireBatchUseCaseIT {
     @Autowired OrderService orderService;
     @Autowired OrderRepository orderRepository;
     @Autowired OrderItemRepository orderItemRepository;
+    @Autowired OrderApprovalHistoryRepository orderApprovalHistoryRepository;
     @Autowired FulfillmentRepository fulfillmentRepository;
     @Autowired RefundRepository refundRepository;
     @Autowired ProductRepository productRepository;
@@ -57,6 +59,7 @@ class PickupExpireBatchUseCaseIT {
         // FK 삭제 순서: refunds → fulfillments → order_items → orders → inventory → products
         refundRepository.deleteAll();
         fulfillmentRepository.deleteAll();
+        orderApprovalHistoryRepository.deleteAll();
         orderItemRepository.deleteAll();
         orderRepository.deleteAll();
         inventoryRepository.deleteAll();

--- a/app/src/test/java/com/personal/happygallery/app/pass/PassExpiryNotificationUseCaseIT.java
+++ b/app/src/test/java/com/personal/happygallery/app/pass/PassExpiryNotificationUseCaseIT.java
@@ -82,8 +82,8 @@ class PassExpiryNotificationUseCaseIT {
         Guest guest1 = guestRepository.save(new Guest("이알림", "01011112222"));
         Guest guest2 = guestRepository.save(new Guest("김알림", "01033334444"));
 
-        // 3일 후 만료 — 7일 내 윈도우 안
-        LocalDateTime soon = LocalDateTime.now(clock).plusDays(3);
+        // 정확히 7일 후 만료 — 알림 대상
+        LocalDateTime soon = LocalDateTime.now(clock).plusDays(7);
         passPurchaseRepository.save(new PassPurchase(guest1, soon, 0L));
         passPurchaseRepository.save(new PassPurchase(guest2, soon, 0L));
 
@@ -112,5 +112,19 @@ class PassExpiryNotificationUseCaseIT {
 
         assertThat(count).isEqualTo(0);
         assertThat(notificationLogRepository.findAll()).isEmpty();
+    }
+
+    @Test
+    void sendExpiryNotifications_sameDaySecondRun_skipsDuplicates() {
+        Guest guest = guestRepository.save(new Guest("중복방지", "01077778888"));
+        LocalDateTime target = LocalDateTime.now(clock).plusDays(7);
+        passPurchaseRepository.save(new PassPurchase(guest, target, 0L));
+
+        int first = passExpiryBatchService.sendExpiryNotifications();
+        int second = passExpiryBatchService.sendExpiryNotifications();
+
+        assertThat(first).isEqualTo(1);
+        assertThat(second).isEqualTo(0);
+        assertThat(notificationLogRepository.findAll()).hasSize(1);
     }
 }

--- a/app/src/test/java/com/personal/happygallery/app/pass/PassPurchaseUseCaseIT.java
+++ b/app/src/test/java/com/personal/happygallery/app/pass/PassPurchaseUseCaseIT.java
@@ -138,9 +138,9 @@ class PassPurchaseUseCaseIT {
 
     @Test
     void notification_query_returnsPassesExpiringWithin7Days() {
-        // 6일 후 만료 → 알림 대상
+        // 정확히 7일 후 만료 → 알림 대상
         Guest guest2 = guestRepository.save(new Guest("이알림", "01088880002"));
-        passPurchaseRepository.save(new PassPurchase(guest, LocalDateTime.now().plusDays(6), 0L));
+        passPurchaseRepository.save(new PassPurchase(guest, LocalDateTime.now().plusDays(7), 0L));
 
         // 30일 후 만료 → 알림 대상 아님
         passPurchaseRepository.save(new PassPurchase(guest2, LocalDateTime.now().plusDays(30), 0L));

--- a/domain/src/main/java/com/personal/happygallery/domain/order/OrderApprovalDecision.java
+++ b/domain/src/main/java/com/personal/happygallery/domain/order/OrderApprovalDecision.java
@@ -1,0 +1,7 @@
+package com.personal.happygallery.domain.order;
+
+public enum OrderApprovalDecision {
+    APPROVE,
+    REJECT,
+    DELAY
+}

--- a/domain/src/main/java/com/personal/happygallery/domain/order/OrderApprovalHistory.java
+++ b/domain/src/main/java/com/personal/happygallery/domain/order/OrderApprovalHistory.java
@@ -1,0 +1,56 @@
+package com.personal.happygallery.domain.order;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "order_approvals")
+public class OrderApprovalHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "order_id", nullable = false)
+    private Long orderId;
+
+    @Column(name = "decided_by_admin_id")
+    private Long decidedByAdminId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private OrderApprovalDecision decision;
+
+    @Column(length = 500)
+    private String reason;
+
+    @Column(name = "decided_at", nullable = false, insertable = false, updatable = false)
+    private LocalDateTime decidedAt;
+
+    protected OrderApprovalHistory() {}
+
+    public OrderApprovalHistory(Long orderId, OrderApprovalDecision decision) {
+        this(orderId, decision, null, null);
+    }
+
+    public OrderApprovalHistory(Long orderId, OrderApprovalDecision decision, Long decidedByAdminId, String reason) {
+        this.orderId = orderId;
+        this.decision = decision;
+        this.decidedByAdminId = decidedByAdminId;
+        this.reason = reason;
+    }
+
+    public Long getId() { return id; }
+    public Long getOrderId() { return orderId; }
+    public Long getDecidedByAdminId() { return decidedByAdminId; }
+    public OrderApprovalDecision getDecision() { return decision; }
+    public String getReason() { return reason; }
+    public LocalDateTime getDecidedAt() { return decidedAt; }
+}

--- a/infra/src/main/java/com/personal/happygallery/infra/notification/NotificationLogRepository.java
+++ b/infra/src/main/java/com/personal/happygallery/infra/notification/NotificationLogRepository.java
@@ -1,7 +1,15 @@
 package com.personal.happygallery.infra.notification;
 
+import com.personal.happygallery.domain.notification.NotificationEventType;
 import com.personal.happygallery.domain.notification.NotificationLog;
+import java.time.LocalDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationLogRepository extends JpaRepository<NotificationLog, Long> {
+
+    boolean existsByGuestIdAndEventTypeAndStatusAndSentAtBetween(Long guestId,
+                                                                 NotificationEventType eventType,
+                                                                 String status,
+                                                                 LocalDateTime start,
+                                                                 LocalDateTime end);
 }

--- a/infra/src/main/java/com/personal/happygallery/infra/order/FulfillmentRepository.java
+++ b/infra/src/main/java/com/personal/happygallery/infra/order/FulfillmentRepository.java
@@ -2,14 +2,22 @@ package com.personal.happygallery.infra.order;
 
 import com.personal.happygallery.domain.order.Fulfillment;
 import com.personal.happygallery.domain.order.OrderStatus;
+import jakarta.persistence.LockModeType;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FulfillmentRepository extends JpaRepository<Fulfillment, Long> {
 
     Optional<Fulfillment> findByOrderId(Long orderId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT f FROM Fulfillment f WHERE f.orderId = :orderId")
+    Optional<Fulfillment> findByOrderIdWithLock(@Param("orderId") Long orderId);
 
     /** 픽업 만료 배치용 조회: status=PICKUP_READY AND pickupDeadlineAt &lt; deadline */
     List<Fulfillment> findByStatusAndPickupDeadlineAtBefore(OrderStatus status, LocalDateTime deadline);

--- a/infra/src/main/java/com/personal/happygallery/infra/order/OrderApprovalHistoryRepository.java
+++ b/infra/src/main/java/com/personal/happygallery/infra/order/OrderApprovalHistoryRepository.java
@@ -1,0 +1,10 @@
+package com.personal.happygallery.infra.order;
+
+import com.personal.happygallery.domain.order.OrderApprovalHistory;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderApprovalHistoryRepository extends JpaRepository<OrderApprovalHistory, Long> {
+
+    List<OrderApprovalHistory> findByOrderId(Long orderId);
+}

--- a/infra/src/main/java/com/personal/happygallery/infra/order/OrderRepository.java
+++ b/infra/src/main/java/com/personal/happygallery/infra/order/OrderRepository.java
@@ -2,9 +2,14 @@ package com.personal.happygallery.infra.order;
 
 import com.personal.happygallery.domain.order.Order;
 import com.personal.happygallery.domain.order.OrderStatus;
+import jakarta.persistence.LockModeType;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
@@ -13,4 +18,8 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
      * {@code status = PAID_APPROVAL_PENDING} AND {@code approvalDeadlineAt < deadline}.
      */
     List<Order> findByStatusAndApprovalDeadlineAtBefore(OrderStatus status, LocalDateTime deadline);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT o FROM Order o WHERE o.id = :orderId")
+    Optional<Order> findByIdWithLock(@Param("orderId") Long orderId);
 }


### PR DESCRIPTION
## 변경 사항
- 주문 승인, 자동환불, 픽업 만료 흐름에 비관적 락과 상태 재검증을 추가하고 `order_approvals` 이력을 저장하도록 정리했습니다.
- 배치 스케줄을 `Asia/Seoul` 기준으로 고정하고, 8회권 만료 알림을 정확히 7일 전 하루 1회만 발송되도록 수정했습니다.
- 주문 승인 이력과 8회권 만료 알림 회귀 테스트를 보강하고, `AGENTS.md`에 Testcontainers 테스트는 `--no-daemon`으로 실행하도록 명시했습니다.

## 테스트 방법
- `GRADLE_USER_HOME=/tmp/.gradle ./gradlew --no-daemon :app:test --tests com.personal.happygallery.app.order.OrderApprovalUseCaseIT --tests com.personal.happygallery.app.order.OrderProductionUseCaseIT --tests com.personal.happygallery.app.order.PickupExpireBatchUseCaseIT --tests com.personal.happygallery.app.pass.PassExpiryNotificationUseCaseIT --tests com.personal.happygallery.app.pass.PassPurchaseUseCaseIT`

## 체크리스트
- [x] 테스트 추가됨
- [x] 문서 업데이트됨
- [x] Breaking change 없음