### PR TITLE
Refactor: 1-2 자동환불 배치 건별 실패 격리 보강

### DIFF
--- a/app/src/main/java/com/personal/happygallery/app/order/OrderAutoRefundBatchService.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/OrderAutoRefundBatchService.java
@@ -66,6 +66,9 @@ public class OrderAutoRefundBatchService {
             } catch (ObjectOptimisticLockingFailureException e) {
                 log.info("주문 자동환불 충돌로 스킵 [orderId={}]", candidate.getId());
                 failureReasons.merge(e.getClass().getSimpleName(), 1, Integer::sum);
+            } catch (Exception e) {
+                log.warn("주문 자동환불 실패 [orderId={}]", candidate.getId(), e);
+                failureReasons.merge(e.getClass().getSimpleName(), 1, Integer::sum);
             }
         }
 

--- a/app/src/test/java/com/personal/happygallery/app/order/OrderApprovalUseCaseIT.java
+++ b/app/src/test/java/com/personal/happygallery/app/order/OrderApprovalUseCaseIT.java
@@ -1,6 +1,7 @@
 package com.personal.happygallery.app.order;
 
 import com.personal.happygallery.app.batch.BatchResult;
+import com.personal.happygallery.app.notification.NotificationService;
 import com.personal.happygallery.common.error.AlreadyRefundedException;
 import com.personal.happygallery.common.error.HappyGalleryException;
 import com.personal.happygallery.domain.order.Order;
@@ -22,11 +23,15 @@ import java.time.LocalDateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -49,6 +54,7 @@ class OrderApprovalUseCaseIT {
     @Autowired OrderAutoRefundBatchService orderAutoRefundBatchService;
     @Autowired OrderService orderService;
     @Autowired Clock clock;
+    @MockitoBean NotificationService notificationService;
 
     @BeforeEach
     void setUp() {
@@ -271,5 +277,46 @@ class OrderApprovalUseCaseIT {
 
         mockMvc.perform(post("/admin/orders/{id}/approve", order.getId()))
                 .andExpect(status().isConflict());
+    }
+
+    @Test
+    void autoRefund_whenOneOrderFails_continuesNextOrderAndCountsFailure() {
+        Product failedProduct = productRepository.save(new Product("자동환불 실패 상품", ProductType.READY_STOCK, 45000L));
+        Product successProduct = productRepository.save(new Product("자동환불 성공 상품", ProductType.READY_STOCK, 55000L));
+        inventoryRepository.save(new Inventory(failedProduct, 1));
+        inventoryRepository.save(new Inventory(successProduct, 1));
+
+        LocalDateTime paidAt = LocalDateTime.now(clock).minusHours(25);
+
+        Order failedOrder = orderRepository.save(new Order(null, 45000L, paidAt, paidAt.plusHours(24)));
+        orderItemRepository.save(new OrderItem(failedOrder, failedProduct.getId(), 1, 45000L));
+        inventoryRepository.findByProductId(failedProduct.getId()).ifPresent(inv -> {
+            inv.deduct(1);
+            inventoryRepository.save(inv);
+        });
+
+        Order successOrder = orderRepository.save(new Order(null, 55000L, paidAt, paidAt.plusHours(24)));
+        orderItemRepository.save(new OrderItem(successOrder, successProduct.getId(), 1, 55000L));
+        inventoryRepository.findByProductId(successProduct.getId()).ifPresent(inv -> {
+            inv.deduct(1);
+            inventoryRepository.save(inv);
+        });
+
+        doThrow(new RuntimeException("알림 전송 실패"))
+                .doNothing()
+                .when(notificationService)
+                .notifyByGuestId(any(), any());
+
+        BatchResult result = orderAutoRefundBatchService.autoRefundExpired();
+
+        assertThat(result.successCount()).isEqualTo(1);
+        assertThat(result.failureCount()).isEqualTo(1);
+        assertThat(result.failureReasons()).containsEntry("RuntimeException", 1);
+
+        Order failedUpdated = orderRepository.findById(failedOrder.getId()).orElseThrow();
+        Order successUpdated = orderRepository.findById(successOrder.getId()).orElseThrow();
+
+        assertThat(failedUpdated.getStatus()).isEqualTo(OrderStatus.PAID_APPROVAL_PENDING);
+        assertThat(successUpdated.getStatus()).isEqualTo(OrderStatus.AUTO_REFUNDED_TIMEOUT);
     }
 }


### PR DESCRIPTION
## 작업 배경
- `docs/1Pager/0001_code_review_plan/codex-plan.md` 1-2(자동환불 배치 처리와 건별 트랜잭션) 점검을 시작했습니다.
- 건별 처리 중 일반 런타임 예외가 발생하면 배치 전체가 중단될 수 있는 리스크를 먼저 보완했습니다.

## 주요 변경
- `OrderAutoRefundBatchService`
  - `ObjectOptimisticLockingFailureException` 외 일반 `Exception`도 건별 실패로 집계하고 다음 주문 처리로 계속 진행하도록 변경
- `OrderApprovalUseCaseIT`
  - 자동환불 대상 주문 2건 중 1건에서 알림 예외가 발생해도
    - 배치가 나머지 주문을 계속 처리하는지
    - 성공/실패 집계가 기대값과 일치하는지
    - 실패 주문 상태가 롤백되어 유지되는지
  를 검증하는 회귀 테스트 추가

## 실행한 테스트
- `GRADLE_USER_HOME=/tmp/.gradle ./gradlew --no-daemon :app:test --tests com.personal.happygallery.app.order.OrderApprovalUseCaseIT`

## 참고
- 이번 PR은 `codex-plan` 1-2 시작 단위입니다. 이후 동일 브랜치에서 1-2 추가 점검/수정을 이어갈 예정입니다.