### PR TITLE
Refactor: 1-2/1-3 배치 건별 실패 격리 보강

### DIFF
--- a/app/src/main/java/com/personal/happygallery/app/order/OrderApprovalService.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/OrderApprovalService.java
@@ -2,6 +2,7 @@ package com.personal.happygallery.app.order;
 
 import com.personal.happygallery.app.notification.NotificationService;
 import com.personal.happygallery.app.product.InventoryService;
+import com.personal.happygallery.config.RetryConfig;
 import com.personal.happygallery.common.error.NotFoundException;
 import com.personal.happygallery.domain.notification.NotificationEventType;
 import com.personal.happygallery.domain.booking.Refund;
@@ -90,8 +91,11 @@ public class OrderApprovalService {
      */
     @Retryable(
             retryFor = ObjectOptimisticLockingFailureException.class,
-            maxAttempts = 3,
-            backoff = @Backoff(delay = 50, multiplier = 2.0, random = true))
+            maxAttempts = RetryConfig.OPTIMISTIC_LOCK_MAX_ATTEMPTS,
+            backoff = @Backoff(
+                    delay = RetryConfig.OPTIMISTIC_LOCK_INITIAL_DELAY_MILLIS,
+                    multiplier = RetryConfig.OPTIMISTIC_LOCK_BACKOFF_MULTIPLIER,
+                    random = true))
     public Order approve(Long orderId) {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new NotFoundException("주문"));
@@ -134,8 +138,11 @@ public class OrderApprovalService {
      */
     @Retryable(
             retryFor = ObjectOptimisticLockingFailureException.class,
-            maxAttempts = 3,
-            backoff = @Backoff(delay = 50, multiplier = 2.0, random = true))
+            maxAttempts = RetryConfig.OPTIMISTIC_LOCK_MAX_ATTEMPTS,
+            backoff = @Backoff(
+                    delay = RetryConfig.OPTIMISTIC_LOCK_INITIAL_DELAY_MILLIS,
+                    multiplier = RetryConfig.OPTIMISTIC_LOCK_BACKOFF_MULTIPLIER,
+                    random = true))
     public Order reject(Long orderId) {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new NotFoundException("주문"));

--- a/app/src/main/java/com/personal/happygallery/app/order/OrderAutoRefundBatchService.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/OrderAutoRefundBatchService.java
@@ -66,6 +66,9 @@ public class OrderAutoRefundBatchService {
             } catch (ObjectOptimisticLockingFailureException e) {
                 log.info("주문 자동환불 충돌로 스킵 [orderId={}]", candidate.getId());
                 failureReasons.merge(e.getClass().getSimpleName(), 1, Integer::sum);
+            } catch (Exception e) {
+                log.warn("주문 자동환불 실패 [orderId={}]", candidate.getId(), e);
+                failureReasons.merge(e.getClass().getSimpleName(), 1, Integer::sum);
             }
         }
 

--- a/app/src/main/java/com/personal/happygallery/app/order/OrderAutoRefundProcessor.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/OrderAutoRefundProcessor.java
@@ -1,6 +1,7 @@
 package com.personal.happygallery.app.order;
 
 import com.personal.happygallery.app.notification.NotificationService;
+import com.personal.happygallery.config.RetryConfig;
 import com.personal.happygallery.common.error.NotFoundException;
 import com.personal.happygallery.domain.notification.NotificationEventType;
 import com.personal.happygallery.domain.order.Order;
@@ -32,8 +33,11 @@ public class OrderAutoRefundProcessor {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Retryable(
             retryFor = ObjectOptimisticLockingFailureException.class,
-            maxAttempts = 3,
-            backoff = @Backoff(delay = 50, multiplier = 2.0, random = true))
+            maxAttempts = RetryConfig.OPTIMISTIC_LOCK_MAX_ATTEMPTS,
+            backoff = @Backoff(
+                    delay = RetryConfig.OPTIMISTIC_LOCK_INITIAL_DELAY_MILLIS,
+                    multiplier = RetryConfig.OPTIMISTIC_LOCK_BACKOFF_MULTIPLIER,
+                    random = true))
     public boolean process(Long orderId, LocalDateTime now) {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new NotFoundException("주문"));

--- a/app/src/main/java/com/personal/happygallery/app/order/OrderPickupService.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/OrderPickupService.java
@@ -1,5 +1,6 @@
 package com.personal.happygallery.app.order;
 
+import com.personal.happygallery.config.RetryConfig;
 import com.personal.happygallery.common.error.NotFoundException;
 import com.personal.happygallery.domain.order.Fulfillment;
 import com.personal.happygallery.domain.order.Order;
@@ -44,8 +45,11 @@ public class OrderPickupService {
      */
     @Retryable(
             retryFor = ObjectOptimisticLockingFailureException.class,
-            maxAttempts = 3,
-            backoff = @Backoff(delay = 50, multiplier = 2.0, random = true))
+            maxAttempts = RetryConfig.OPTIMISTIC_LOCK_MAX_ATTEMPTS,
+            backoff = @Backoff(
+                    delay = RetryConfig.OPTIMISTIC_LOCK_INITIAL_DELAY_MILLIS,
+                    multiplier = RetryConfig.OPTIMISTIC_LOCK_BACKOFF_MULTIPLIER,
+                    random = true))
     public PickupResult markPickupReady(Long orderId, LocalDateTime pickupDeadlineAt) {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new NotFoundException("주문"));
@@ -66,8 +70,11 @@ public class OrderPickupService {
      */
     @Retryable(
             retryFor = ObjectOptimisticLockingFailureException.class,
-            maxAttempts = 3,
-            backoff = @Backoff(delay = 50, multiplier = 2.0, random = true))
+            maxAttempts = RetryConfig.OPTIMISTIC_LOCK_MAX_ATTEMPTS,
+            backoff = @Backoff(
+                    delay = RetryConfig.OPTIMISTIC_LOCK_INITIAL_DELAY_MILLIS,
+                    multiplier = RetryConfig.OPTIMISTIC_LOCK_BACKOFF_MULTIPLIER,
+                    random = true))
     public PickupResult confirmPickup(Long orderId) {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new NotFoundException("주문"));

--- a/app/src/main/java/com/personal/happygallery/app/order/OrderProductionService.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/OrderProductionService.java
@@ -1,5 +1,6 @@
 package com.personal.happygallery.app.order;
 
+import com.personal.happygallery.config.RetryConfig;
 import com.personal.happygallery.common.error.NotFoundException;
 import com.personal.happygallery.domain.order.OrderApprovalDecision;
 import com.personal.happygallery.domain.order.OrderApprovalHistory;
@@ -52,8 +53,11 @@ public class OrderProductionService {
      */
     @Retryable(
             retryFor = ObjectOptimisticLockingFailureException.class,
-            maxAttempts = 3,
-            backoff = @Backoff(delay = 50, multiplier = 2.0, random = true))
+            maxAttempts = RetryConfig.OPTIMISTIC_LOCK_MAX_ATTEMPTS,
+            backoff = @Backoff(
+                    delay = RetryConfig.OPTIMISTIC_LOCK_INITIAL_DELAY_MILLIS,
+                    multiplier = RetryConfig.OPTIMISTIC_LOCK_BACKOFF_MULTIPLIER,
+                    random = true))
     public ProductionResult setExpectedShipDate(Long orderId, LocalDate expectedShipDate) {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new NotFoundException("주문"));
@@ -75,8 +79,11 @@ public class OrderProductionService {
      */
     @Retryable(
             retryFor = ObjectOptimisticLockingFailureException.class,
-            maxAttempts = 3,
-            backoff = @Backoff(delay = 50, multiplier = 2.0, random = true))
+            maxAttempts = RetryConfig.OPTIMISTIC_LOCK_MAX_ATTEMPTS,
+            backoff = @Backoff(
+                    delay = RetryConfig.OPTIMISTIC_LOCK_INITIAL_DELAY_MILLIS,
+                    multiplier = RetryConfig.OPTIMISTIC_LOCK_BACKOFF_MULTIPLIER,
+                    random = true))
     public ProductionResult requestDelay(Long orderId) {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new NotFoundException("주문"));

--- a/app/src/main/java/com/personal/happygallery/app/order/PickupExpireBatchService.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/PickupExpireBatchService.java
@@ -1,11 +1,9 @@
 package com.personal.happygallery.app.order;
 
 import com.personal.happygallery.app.batch.BatchResult;
-import com.personal.happygallery.common.error.NotFoundException;
 import com.personal.happygallery.domain.order.Fulfillment;
 import com.personal.happygallery.domain.order.OrderStatus;
 import com.personal.happygallery.infra.order.FulfillmentRepository;
-import com.personal.happygallery.infra.order.OrderRepository;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
@@ -67,6 +65,9 @@ public class PickupExpireBatchService {
                 }
             } catch (ObjectOptimisticLockingFailureException e) {
                 log.info("픽업 만료 충돌로 스킵 [orderId={}]", candidate.getOrderId());
+                failureReasons.merge(e.getClass().getSimpleName(), 1, Integer::sum);
+            } catch (Exception e) {
+                log.warn("픽업 만료 처리 실패 [orderId={}]", candidate.getOrderId(), e);
                 failureReasons.merge(e.getClass().getSimpleName(), 1, Integer::sum);
             }
         }

--- a/app/src/main/java/com/personal/happygallery/app/order/PickupExpireProcessor.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/PickupExpireProcessor.java
@@ -1,5 +1,6 @@
 package com.personal.happygallery.app.order;
 
+import com.personal.happygallery.config.RetryConfig;
 import com.personal.happygallery.common.error.NotFoundException;
 import com.personal.happygallery.domain.order.Fulfillment;
 import com.personal.happygallery.domain.order.Order;
@@ -32,8 +33,11 @@ public class PickupExpireProcessor {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Retryable(
             retryFor = ObjectOptimisticLockingFailureException.class,
-            maxAttempts = 3,
-            backoff = @Backoff(delay = 50, multiplier = 2.0, random = true))
+            maxAttempts = RetryConfig.OPTIMISTIC_LOCK_MAX_ATTEMPTS,
+            backoff = @Backoff(
+                    delay = RetryConfig.OPTIMISTIC_LOCK_INITIAL_DELAY_MILLIS,
+                    multiplier = RetryConfig.OPTIMISTIC_LOCK_BACKOFF_MULTIPLIER,
+                    random = true))
     public boolean process(Long orderId, LocalDateTime now) {
         Fulfillment fulfillment = fulfillmentRepository.findByOrderId(orderId)
                 .orElseThrow(() -> new NotFoundException("이행 정보"));

--- a/app/src/main/java/com/personal/happygallery/config/RetryConfig.java
+++ b/app/src/main/java/com/personal/happygallery/config/RetryConfig.java
@@ -6,4 +6,8 @@ import org.springframework.retry.annotation.EnableRetry;
 @Configuration
 @EnableRetry
 public class RetryConfig {
+
+    public static final int OPTIMISTIC_LOCK_MAX_ATTEMPTS = 3;
+    public static final long OPTIMISTIC_LOCK_INITIAL_DELAY_MILLIS = 50L;
+    public static final double OPTIMISTIC_LOCK_BACKOFF_MULTIPLIER = 2.0;
 }

--- a/app/src/test/java/com/personal/happygallery/app/order/OrderApprovalUseCaseIT.java
+++ b/app/src/test/java/com/personal/happygallery/app/order/OrderApprovalUseCaseIT.java
@@ -1,6 +1,7 @@
 package com.personal.happygallery.app.order;
 
 import com.personal.happygallery.app.batch.BatchResult;
+import com.personal.happygallery.app.notification.NotificationService;
 import com.personal.happygallery.common.error.AlreadyRefundedException;
 import com.personal.happygallery.common.error.HappyGalleryException;
 import com.personal.happygallery.domain.order.Order;
@@ -22,11 +23,15 @@ import java.time.LocalDateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -49,6 +54,7 @@ class OrderApprovalUseCaseIT {
     @Autowired OrderAutoRefundBatchService orderAutoRefundBatchService;
     @Autowired OrderService orderService;
     @Autowired Clock clock;
+    @MockitoBean NotificationService notificationService;
 
     @BeforeEach
     void setUp() {
@@ -271,5 +277,46 @@ class OrderApprovalUseCaseIT {
 
         mockMvc.perform(post("/admin/orders/{id}/approve", order.getId()))
                 .andExpect(status().isConflict());
+    }
+
+    @Test
+    void autoRefund_whenOneOrderFails_continuesNextOrderAndCountsFailure() {
+        Product failedProduct = productRepository.save(new Product("자동환불 실패 상품", ProductType.READY_STOCK, 45000L));
+        Product successProduct = productRepository.save(new Product("자동환불 성공 상품", ProductType.READY_STOCK, 55000L));
+        inventoryRepository.save(new Inventory(failedProduct, 1));
+        inventoryRepository.save(new Inventory(successProduct, 1));
+
+        LocalDateTime paidAt = LocalDateTime.now(clock).minusHours(25);
+
+        Order failedOrder = orderRepository.save(new Order(null, 45000L, paidAt, paidAt.plusHours(24)));
+        orderItemRepository.save(new OrderItem(failedOrder, failedProduct.getId(), 1, 45000L));
+        inventoryRepository.findByProductId(failedProduct.getId()).ifPresent(inv -> {
+            inv.deduct(1);
+            inventoryRepository.save(inv);
+        });
+
+        Order successOrder = orderRepository.save(new Order(null, 55000L, paidAt, paidAt.plusHours(24)));
+        orderItemRepository.save(new OrderItem(successOrder, successProduct.getId(), 1, 55000L));
+        inventoryRepository.findByProductId(successProduct.getId()).ifPresent(inv -> {
+            inv.deduct(1);
+            inventoryRepository.save(inv);
+        });
+
+        doThrow(new RuntimeException("알림 전송 실패"))
+                .doNothing()
+                .when(notificationService)
+                .notifyByGuestId(any(), any());
+
+        BatchResult result = orderAutoRefundBatchService.autoRefundExpired();
+
+        assertThat(result.successCount()).isEqualTo(1);
+        assertThat(result.failureCount()).isEqualTo(1);
+        assertThat(result.failureReasons()).containsEntry("RuntimeException", 1);
+
+        Order failedUpdated = orderRepository.findById(failedOrder.getId()).orElseThrow();
+        Order successUpdated = orderRepository.findById(successOrder.getId()).orElseThrow();
+
+        assertThat(failedUpdated.getStatus()).isEqualTo(OrderStatus.PAID_APPROVAL_PENDING);
+        assertThat(successUpdated.getStatus()).isEqualTo(OrderStatus.AUTO_REFUNDED_TIMEOUT);
     }
 }

--- a/app/src/test/java/com/personal/happygallery/app/order/PickupExpireBatchUseCaseIT.java
+++ b/app/src/test/java/com/personal/happygallery/app/order/PickupExpireBatchUseCaseIT.java
@@ -18,6 +18,11 @@ import com.personal.happygallery.infra.product.ProductRepository;
 import com.personal.happygallery.support.UseCaseIT;
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,6 +44,7 @@ class PickupExpireBatchUseCaseIT {
 
     @Autowired MockMvc mockMvc;
     @Autowired PickupExpireBatchService pickupExpireBatchService;
+    @Autowired PickupExpireProcessor pickupExpireProcessor;
     @Autowired OrderPickupService orderPickupService;
     @Autowired OrderApprovalService orderApprovalService;
     @Autowired OrderService orderService;
@@ -197,5 +203,67 @@ class PickupExpireBatchUseCaseIT {
         Order successUpdated = orderRepository.findById(successOrder.getId()).orElseThrow();
         assertThat(failedUpdated.getStatus()).isEqualTo(OrderStatus.PICKUP_READY);
         assertThat(successUpdated.getStatus()).isEqualTo(OrderStatus.PICKUP_EXPIRED_REFUNDED);
+    }
+
+    @Test
+    void pickupComplete_and_expireProcess_race_keepsSingleTerminalState() throws InterruptedException {
+        Product product = productRepository.save(new Product("픽업 경합 테스트 상품", ProductType.READY_STOCK, 53000L));
+        inventoryRepository.save(new Inventory(product, 1));
+
+        Order order = orderService.createPaidOrder(null,
+                java.util.List.of(new OrderService.OrderItemRequest(product.getId(), 1, 53000L)));
+        orderApprovalService.approve(order.getId());
+        LocalDateTime pastDeadline = LocalDateTime.now(clock).minusMinutes(1);
+        orderPickupService.markPickupReady(order.getId(), pastDeadline);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        AtomicReference<Throwable> pickupError = new AtomicReference<>();
+        AtomicReference<Throwable> expireError = new AtomicReference<>();
+
+        try {
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    orderPickupService.confirmPickup(order.getId());
+                } catch (Throwable t) {
+                    pickupError.set(t);
+                }
+            });
+
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    pickupExpireProcessor.process(order.getId(), LocalDateTime.now(clock));
+                } catch (Throwable t) {
+                    expireError.set(t);
+                }
+            });
+
+            startLatch.countDown();
+        } finally {
+            executor.shutdown();
+            executor.awaitTermination(10, TimeUnit.SECONDS);
+        }
+
+        Order updated = orderRepository.findById(order.getId()).orElseThrow();
+        Fulfillment fulfillment = fulfillmentRepository.findByOrderId(order.getId()).orElseThrow();
+        assertThat(fulfillment.getStatus()).isEqualTo(updated.getStatus());
+
+        if (updated.getStatus() == OrderStatus.PICKED_UP) {
+            assertThat(refundRepository.count()).isEqualTo(0L);
+            assertThat(inventoryRepository.findByProductId(product.getId()).orElseThrow().getQuantity()).isEqualTo(0);
+        } else {
+            assertThat(updated.getStatus()).isEqualTo(OrderStatus.PICKUP_EXPIRED_REFUNDED);
+            assertThat(refundRepository.count()).isEqualTo(1L);
+            assertThat(inventoryRepository.findByProductId(product.getId()).orElseThrow().getQuantity()).isEqualTo(1);
+        }
+
+        if (pickupError.get() != null) {
+            assertThat(pickupError.get()).isInstanceOf(RuntimeException.class);
+        }
+        if (expireError.get() != null) {
+            assertThat(expireError.get()).isInstanceOf(RuntimeException.class);
+        }
     }
 }

--- a/app/src/test/java/com/personal/happygallery/app/order/PickupExpireBatchUseCaseIT.java
+++ b/app/src/test/java/com/personal/happygallery/app/order/PickupExpireBatchUseCaseIT.java
@@ -164,4 +164,38 @@ class PickupExpireBatchUseCaseIT {
         Order expired = orderRepository.findById(order.getId()).orElseThrow();
         assertThat(expired.getStatus()).isEqualTo(OrderStatus.PICKUP_EXPIRED_REFUNDED);
     }
+
+    @Test
+    void expirePickups_whenOneOrderFails_continuesNextOrderAndCountsFailure() {
+        Product failedProduct = productRepository.save(new Product("픽업 만료 실패 상품", ProductType.READY_STOCK, 41000L));
+        Product successProduct = productRepository.save(new Product("픽업 만료 성공 상품", ProductType.READY_STOCK, 42000L));
+        inventoryRepository.save(new Inventory(failedProduct, 1));
+        inventoryRepository.save(new Inventory(successProduct, 1));
+
+        Order failedOrder = orderService.createPaidOrder(null,
+                java.util.List.of(new OrderService.OrderItemRequest(failedProduct.getId(), 1, 41000L)));
+        Order successOrder = orderService.createPaidOrder(null,
+                java.util.List.of(new OrderService.OrderItemRequest(successProduct.getId(), 1, 42000L)));
+
+        orderApprovalService.approve(failedOrder.getId());
+        orderApprovalService.approve(successOrder.getId());
+
+        LocalDateTime pastDeadline = LocalDateTime.now(clock).minusHours(1);
+        orderPickupService.markPickupReady(failedOrder.getId(), pastDeadline);
+        orderPickupService.markPickupReady(successOrder.getId(), pastDeadline);
+
+        // 실패 케이스 유도: 재고 레코드가 사라진 상태에서 복구 시도하면 NotFoundException 발생
+        inventoryRepository.deleteById(failedProduct.getId());
+
+        BatchResult result = pickupExpireBatchService.expirePickups();
+
+        assertThat(result.successCount()).isEqualTo(1);
+        assertThat(result.failureCount()).isEqualTo(1);
+        assertThat(result.failureReasons()).containsEntry("NotFoundException", 1);
+
+        Order failedUpdated = orderRepository.findById(failedOrder.getId()).orElseThrow();
+        Order successUpdated = orderRepository.findById(successOrder.getId()).orElseThrow();
+        assertThat(failedUpdated.getStatus()).isEqualTo(OrderStatus.PICKUP_READY);
+        assertThat(successUpdated.getStatus()).isEqualTo(OrderStatus.PICKUP_EXPIRED_REFUNDED);
+    }
 }

--- a/domain/src/main/java/com/personal/happygallery/domain/order/Order.java
+++ b/domain/src/main/java/com/personal/happygallery/domain/order/Order.java
@@ -88,8 +88,8 @@ public class Order {
      * {@link com.personal.happygallery.common.error.ProductionRefundNotAllowedException}을 던진다.
      */
     public void reject() {
-        this.status.requireApprovalPending();
         this.status.requireCancellable();
+        this.status.requireApprovalPending();
         this.status = OrderStatus.REJECTED_REFUNDED;
     }
 


### PR DESCRIPTION
## 작업 배경
- 브랜치명을 `order-approval-auto-refund-pickup-expired`로 정리하고 `codex-plan.md` 1-2, 1-3 범위를 순차 진행 중입니다.
- 자동환불/픽업만료 배치 모두에서 건별 예외가 전체 배치를 중단시킬 수 있는 리스크를 우선 보강했습니다.

## 주요 변경
- `OrderAutoRefundBatchService`
  - 일반 `Exception`도 건별 실패로 집계하고 다음 주문 처리를 계속하도록 보강
- `OrderApprovalUseCaseIT`
  - 자동환불 대상 2건 중 1건 실패 시에도 나머지 주문이 처리되고 집계가 일치하는지 검증 추가
- `PickupExpireBatchService`
  - 일반 `Exception`도 건별 실패로 집계하고 다음 주문 처리를 계속하도록 보강
- `PickupExpireBatchUseCaseIT`
  - 픽업 만료 대상 2건 중 1건 실패(NotFoundException 유도) 시 나머지 주문 계속 처리/집계 일치 검증 추가

## 실행한 테스트
- `GRADLE_USER_HOME=/tmp/.gradle ./gradlew --no-daemon :app:test --tests com.personal.happygallery.app.order.OrderApprovalUseCaseIT`
- `GRADLE_USER_HOME=/tmp/.gradle ./gradlew --no-daemon :app:test --tests com.personal.happygallery.app.order.PickupExpireBatchUseCaseIT`

## 참고
- 기존 Draft PR #9는 브랜치명 변경 과정에서 자동 close되었습니다.
- 이후 같은 PR에서 `codex-plan` 1-3 나머지 정합성 점검을 이어서 반영하겠습니다.