### PR TITLE
Test: 배치 공통 로깅 AOP 검증 및 2-1 리뷰 시작

### DIFF
--- a/app/src/main/java/com/personal/happygallery/app/batch/BatchLoggingAspect.java
+++ b/app/src/main/java/com/personal/happygallery/app/batch/BatchLoggingAspect.java
@@ -17,7 +17,7 @@ public class BatchLoggingAspect {
     @Around("@annotation(batchJob)")
     public Object logBatchExecution(ProceedingJoinPoint joinPoint, BatchJob batchJob) throws Throwable {
         long startedAt = System.nanoTime();
-        String jobName = batchJob.value();
+        String jobName = resolveJobName(joinPoint, batchJob);
         log.info("[배치] {} 시작", jobName);
 
         try {
@@ -49,5 +49,13 @@ public class BatchLoggingAspect {
             log.error("[배치] {} 실패 ({}ms)", jobName, durationMs, t);
             throw t;
         }
+    }
+
+    private String resolveJobName(ProceedingJoinPoint joinPoint, BatchJob batchJob) {
+        String configuredName = batchJob.value();
+        if (configuredName != null && !configuredName.isBlank()) {
+            return configuredName;
+        }
+        return joinPoint.getSignature().toShortString();
     }
 }

--- a/app/src/test/java/com/personal/happygallery/app/batch/BatchLoggingAspectTest.java
+++ b/app/src/test/java/com/personal/happygallery/app/batch/BatchLoggingAspectTest.java
@@ -1,0 +1,64 @@
+package com.personal.happygallery.app.batch;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.Signature;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(OutputCaptureExtension.class)
+class BatchLoggingAspectTest {
+
+    private final BatchLoggingAspect aspect = new BatchLoggingAspect();
+
+    @Test
+    void logBatchExecution_returnsBatchResultAsIs() throws Throwable {
+        ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+        BatchJob batchJob = mock(BatchJob.class);
+        BatchResult result = BatchResult.successOnly(3);
+
+        when(batchJob.value()).thenReturn("주문 자동환불");
+        when(joinPoint.proceed()).thenReturn(result);
+
+        Object actual = aspect.logBatchExecution(joinPoint, batchJob);
+
+        assertThat(actual).isEqualTo(result);
+        verify(joinPoint).proceed();
+    }
+
+    @Test
+    void logBatchExecution_rethrowsException() throws Throwable {
+        ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+        BatchJob batchJob = mock(BatchJob.class);
+        RuntimeException failure = new RuntimeException("boom");
+
+        when(batchJob.value()).thenReturn("픽업 만료");
+        when(joinPoint.proceed()).thenThrow(failure);
+
+        assertThatThrownBy(() -> aspect.logBatchExecution(joinPoint, batchJob))
+                .isSameAs(failure);
+    }
+
+    @Test
+    void logBatchExecution_blankBatchName_usesMethodSignature(CapturedOutput output) throws Throwable {
+        ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+        Signature signature = mock(Signature.class);
+        BatchJob batchJob = mock(BatchJob.class);
+
+        when(batchJob.value()).thenReturn("  ");
+        when(joinPoint.getSignature()).thenReturn(signature);
+        when(signature.toShortString()).thenReturn("BatchScheduler.runOrderAutoRefund()");
+        when(joinPoint.proceed()).thenReturn(BatchResult.successOnly(1));
+
+        aspect.logBatchExecution(joinPoint, batchJob);
+
+        assertThat(output).contains("BatchScheduler.runOrderAutoRefund()");
+    }
+}

--- a/app/src/test/java/com/personal/happygallery/app/batch/BatchSchedulerTest.java
+++ b/app/src/test/java/com/personal/happygallery/app/batch/BatchSchedulerTest.java
@@ -1,0 +1,47 @@
+package com.personal.happygallery.app.batch;
+
+import com.personal.happygallery.app.booking.BookingReminderBatchService;
+import com.personal.happygallery.app.order.OrderAutoRefundBatchService;
+import com.personal.happygallery.app.order.PickupExpireBatchService;
+import com.personal.happygallery.app.pass.PassExpiryBatchService;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BatchSchedulerTest {
+
+    private final OrderAutoRefundBatchService orderAutoRefundBatchService = mock(OrderAutoRefundBatchService.class);
+    private final PickupExpireBatchService pickupExpireBatchService = mock(PickupExpireBatchService.class);
+    private final PassExpiryBatchService passExpiryBatchService = mock(PassExpiryBatchService.class);
+    private final BookingReminderBatchService bookingReminderBatchService = mock(BookingReminderBatchService.class);
+
+    private final BatchScheduler batchScheduler = new BatchScheduler(
+            orderAutoRefundBatchService,
+            pickupExpireBatchService,
+            passExpiryBatchService,
+            bookingReminderBatchService);
+
+    @Test
+    void runOrderAutoRefund_delegatesAndReturnsResult() {
+        BatchResult expected = BatchResult.successOnly(2);
+        when(orderAutoRefundBatchService.autoRefundExpired()).thenReturn(expected);
+
+        BatchResult actual = batchScheduler.runOrderAutoRefund();
+
+        assertThat(actual).isEqualTo(expected);
+        verify(orderAutoRefundBatchService).autoRefundExpired();
+    }
+
+    @Test
+    void runPickupExpire_propagatesException() {
+        RuntimeException failure = new RuntimeException("pickup failed");
+        when(pickupExpireBatchService.expirePickups()).thenThrow(failure);
+
+        assertThatThrownBy(() -> batchScheduler.runPickupExpire())
+                .isSameAs(failure);
+    }
+}


### PR DESCRIPTION
## 작업 배경
- `docs/1Pager/0001_code_review_plan/codex-plan.md` 2-1(배치 공통 로깅/AOP)부터 리뷰를 시작했습니다.
- 우선 "예외를 삼키지 않는지"와 "스케줄러 반환값/예외 흐름"을 테스트로 고정했습니다.

## 주요 변경
- `BatchLoggingAspect`
  - `@BatchJob` 이름이 비어 있을 때 메서드 시그니처를 fallback 이름으로 사용
- `BatchLoggingAspectTest` 추가
  - `BatchResult` 반환 시 원값 유지 검증
  - 내부 예외 발생 시 재전파(삼키지 않음) 검증
  - 빈 배치명에서 시그니처 fallback 로그 검증
- `BatchSchedulerTest` 추가
  - 스케줄러 메서드가 배치 서비스 결과를 그대로 반환하는지 검증
  - 하위 서비스 예외를 그대로 전파하는지 검증

## 실행한 테스트
- `GRADLE_USER_HOME=/tmp/.gradle ./gradlew --no-daemon :app:test --tests com.personal.happygallery.app.batch.BatchLoggingAspectTest`
- `GRADLE_USER_HOME=/tmp/.gradle ./gradlew --no-daemon :app:test --tests com.personal.happygallery.app.batch.BatchLoggingAspectTest --tests com.personal.happygallery.app.batch.BatchSchedulerTest`

## 다음 작업
- 같은 PR에서 `2-1` 남은 관점(운영 로그 정보량/노출 수준) 점검 후 필요 시 추가 보강 예정