### PR TITLE
Chore: 주문 상태 승인 이력 작업 브랜치 생성

### DIFF
--- a/app/src/main/java/com/personal/happygallery/app/order/OrderAutoRefundProcessor.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/OrderAutoRefundProcessor.java
@@ -5,9 +5,14 @@ import com.personal.happygallery.config.RetryConfig;
 import com.personal.happygallery.common.error.NotFoundException;
 import com.personal.happygallery.domain.notification.NotificationEventType;
 import com.personal.happygallery.domain.order.Order;
+import com.personal.happygallery.domain.order.OrderApprovalDecision;
+import com.personal.happygallery.domain.order.OrderApprovalHistory;
 import com.personal.happygallery.domain.order.OrderStatus;
+import com.personal.happygallery.infra.order.OrderApprovalHistoryRepository;
 import com.personal.happygallery.infra.order.OrderRepository;
 import java.time.LocalDateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
@@ -18,15 +23,20 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class OrderAutoRefundProcessor {
 
+    private static final Logger log = LoggerFactory.getLogger(OrderAutoRefundProcessor.class);
+
     private final OrderRepository orderRepository;
     private final OrderApprovalService orderApprovalService;
+    private final OrderApprovalHistoryRepository orderApprovalHistoryRepository;
     private final NotificationService notificationService;
 
     public OrderAutoRefundProcessor(OrderRepository orderRepository,
                                     OrderApprovalService orderApprovalService,
+                                    OrderApprovalHistoryRepository orderApprovalHistoryRepository,
                                     NotificationService notificationService) {
         this.orderRepository = orderRepository;
         this.orderApprovalService = orderApprovalService;
+        this.orderApprovalHistoryRepository = orderApprovalHistoryRepository;
         this.notificationService = notificationService;
     }
 
@@ -51,8 +61,15 @@ public class OrderAutoRefundProcessor {
         orderApprovalService.restoreInventory(order);
         orderApprovalService.processRefund(order);
         order.markAutoRefunded();
+        orderApprovalHistoryRepository.save(
+                new OrderApprovalHistory(order.getId(), OrderApprovalDecision.AUTO_REFUND));
         orderRepository.saveAndFlush(order);
-        notificationService.notifyByGuestId(order.getGuestId(), NotificationEventType.ORDER_REFUNDED);
+
+        try {
+            notificationService.notifyByGuestId(order.getGuestId(), NotificationEventType.ORDER_REFUNDED);
+        } catch (Exception e) {
+            log.warn("자동환불 알림 실패 [orderId={}] — 환불은 정상 처리됨", orderId, e);
+        }
         return true;
     }
 }

--- a/app/src/main/java/com/personal/happygallery/app/order/PickupExpireProcessor.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/PickupExpireProcessor.java
@@ -1,13 +1,17 @@
 package com.personal.happygallery.app.order;
 
+import com.personal.happygallery.app.notification.NotificationService;
 import com.personal.happygallery.config.RetryConfig;
 import com.personal.happygallery.common.error.NotFoundException;
+import com.personal.happygallery.domain.notification.NotificationEventType;
 import com.personal.happygallery.domain.order.Fulfillment;
 import com.personal.happygallery.domain.order.Order;
 import com.personal.happygallery.domain.order.OrderStatus;
 import com.personal.happygallery.infra.order.FulfillmentRepository;
 import com.personal.happygallery.infra.order.OrderRepository;
 import java.time.LocalDateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
@@ -18,16 +22,21 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class PickupExpireProcessor {
 
+    private static final Logger log = LoggerFactory.getLogger(PickupExpireProcessor.class);
+
     private final FulfillmentRepository fulfillmentRepository;
     private final OrderRepository orderRepository;
     private final OrderApprovalService orderApprovalService;
+    private final NotificationService notificationService;
 
     public PickupExpireProcessor(FulfillmentRepository fulfillmentRepository,
                                  OrderRepository orderRepository,
-                                 OrderApprovalService orderApprovalService) {
+                                 OrderApprovalService orderApprovalService,
+                                 NotificationService notificationService) {
         this.fulfillmentRepository = fulfillmentRepository;
         this.orderRepository = orderRepository;
         this.orderApprovalService = orderApprovalService;
+        this.notificationService = notificationService;
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -61,6 +70,12 @@ public class PickupExpireProcessor {
 
         orderRepository.save(order);
         fulfillmentRepository.saveAndFlush(fulfillment);
+
+        try {
+            notificationService.notifyByGuestId(order.getGuestId(), NotificationEventType.ORDER_REFUNDED);
+        } catch (Exception e) {
+            log.warn("픽업 만료 알림 실패 [orderId={}] — 환불은 정상 처리됨", orderId, e);
+        }
         return true;
     }
 }

--- a/app/src/main/java/com/personal/happygallery/app/pass/PassExpireProcessor.java
+++ b/app/src/main/java/com/personal/happygallery/app/pass/PassExpireProcessor.java
@@ -1,0 +1,44 @@
+package com.personal.happygallery.app.pass;
+
+import com.personal.happygallery.common.error.NotFoundException;
+import com.personal.happygallery.domain.pass.PassLedger;
+import com.personal.happygallery.domain.pass.PassLedgerType;
+import com.personal.happygallery.domain.pass.PassPurchase;
+import com.personal.happygallery.infra.pass.PassLedgerRepository;
+import com.personal.happygallery.infra.pass.PassPurchaseRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class PassExpireProcessor {
+
+    private static final Logger log = LoggerFactory.getLogger(PassExpireProcessor.class);
+
+    private final PassPurchaseRepository passPurchaseRepository;
+    private final PassLedgerRepository passLedgerRepository;
+
+    public PassExpireProcessor(PassPurchaseRepository passPurchaseRepository,
+                               PassLedgerRepository passLedgerRepository) {
+        this.passPurchaseRepository = passPurchaseRepository;
+        this.passLedgerRepository = passLedgerRepository;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public boolean process(Long passId) {
+        PassPurchase pass = passPurchaseRepository.findById(passId)
+                .orElseThrow(() -> new NotFoundException("8회권"));
+        if (pass.getRemainingCredits() <= 0) {
+            return false;
+        }
+
+        int creditsToExpire = pass.getRemainingCredits();
+        passLedgerRepository.save(new PassLedger(pass, PassLedgerType.EXPIRE, creditsToExpire));
+        pass.expire();
+        passPurchaseRepository.save(pass);
+        log.info("Pass expired [passId={}] credits소멸={}", pass.getId(), creditsToExpire);
+        return true;
+    }
+}

--- a/app/src/main/java/com/personal/happygallery/app/pass/PassExpiryBatchService.java
+++ b/app/src/main/java/com/personal/happygallery/app/pass/PassExpiryBatchService.java
@@ -3,15 +3,14 @@ package com.personal.happygallery.app.pass;
 import com.personal.happygallery.app.batch.BatchResult;
 import com.personal.happygallery.app.notification.NotificationService;
 import com.personal.happygallery.domain.notification.NotificationEventType;
-import com.personal.happygallery.domain.pass.PassLedger;
-import com.personal.happygallery.domain.pass.PassLedgerType;
 import com.personal.happygallery.domain.pass.PassPurchase;
 import com.personal.happygallery.infra.notification.NotificationLogRepository;
-import com.personal.happygallery.infra.pass.PassLedgerRepository;
 import com.personal.happygallery.infra.pass.PassPurchaseRepository;
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -24,18 +23,18 @@ public class PassExpiryBatchService {
     private static final Logger log = LoggerFactory.getLogger(PassExpiryBatchService.class);
 
     private final PassPurchaseRepository passPurchaseRepository;
-    private final PassLedgerRepository passLedgerRepository;
+    private final PassExpireProcessor passExpireProcessor;
     private final NotificationLogRepository notificationLogRepository;
     private final NotificationService notificationService;
     private final Clock clock;
 
     public PassExpiryBatchService(PassPurchaseRepository passPurchaseRepository,
-                                  PassLedgerRepository passLedgerRepository,
+                                  PassExpireProcessor passExpireProcessor,
                                   NotificationLogRepository notificationLogRepository,
                                   NotificationService notificationService,
                                   Clock clock) {
         this.passPurchaseRepository = passPurchaseRepository;
-        this.passLedgerRepository = passLedgerRepository;
+        this.passExpireProcessor = passExpireProcessor;
         this.notificationLogRepository = notificationLogRepository;
         this.notificationService = notificationService;
         this.clock = clock;
@@ -55,16 +54,21 @@ public class PassExpiryBatchService {
         LocalDateTime now = LocalDateTime.now(clock);
         List<PassPurchase> expired = passPurchaseRepository
                 .findByExpiresAtBeforeAndRemainingCreditsGreaterThan(now, 0);
+        int processed = 0;
+        Map<String, Integer> failureReasons = new LinkedHashMap<>();
 
         for (PassPurchase pass : expired) {
-            int creditsToExpire = pass.getRemainingCredits();
-            passLedgerRepository.save(new PassLedger(pass, PassLedgerType.EXPIRE, creditsToExpire));
-            pass.expire();
-            passPurchaseRepository.save(pass);
-            log.info("Pass expired [passId={}] credits소멸={}", pass.getId(), creditsToExpire);
+            try {
+                if (passExpireProcessor.process(pass.getId())) {
+                    processed++;
+                }
+            } catch (Exception e) {
+                log.warn("8회권 만료 처리 실패 [passId={}]", pass.getId(), e);
+                failureReasons.merge(e.getClass().getSimpleName(), 1, Integer::sum);
+            }
         }
 
-        return BatchResult.successOnly(expired.size());
+        return BatchResult.of(processed, failureReasons);
     }
 
     /**

--- a/app/src/main/java/com/personal/happygallery/config/RetryConfig.java
+++ b/app/src/main/java/com/personal/happygallery/config/RetryConfig.java
@@ -1,10 +1,11 @@
 package com.personal.happygallery.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 import org.springframework.retry.annotation.EnableRetry;
 
 @Configuration
-@EnableRetry
+@EnableRetry(order = Ordered.LOWEST_PRECEDENCE - 1)
 public class RetryConfig {
 
     public static final int OPTIMISTIC_LOCK_MAX_ATTEMPTS = 3;

--- a/app/src/main/resources/db/migration/V7__widen_order_approval_decision.sql
+++ b/app/src/main/resources/db/migration/V7__widen_order_approval_decision.sql
@@ -1,0 +1,3 @@
+-- AUTO_REFUND(11자) 수용을 위해 decision 컬럼 길이 확장
+ALTER TABLE order_approvals
+    MODIFY COLUMN decision VARCHAR(20) NOT NULL COMMENT 'APPROVE | REJECT | DELAY | AUTO_REFUND';

--- a/app/src/test/java/com/personal/happygallery/app/order/OrderApprovalUseCaseIT.java
+++ b/app/src/test/java/com/personal/happygallery/app/order/OrderApprovalUseCaseIT.java
@@ -280,28 +280,29 @@ class OrderApprovalUseCaseIT {
     }
 
     @Test
-    void autoRefund_whenOneOrderFails_continuesNextOrderAndCountsFailure() {
-        Product failedProduct = productRepository.save(new Product("자동환불 실패 상품", ProductType.READY_STOCK, 45000L));
-        Product successProduct = productRepository.save(new Product("자동환불 성공 상품", ProductType.READY_STOCK, 55000L));
-        inventoryRepository.save(new Inventory(failedProduct, 1));
-        inventoryRepository.save(new Inventory(successProduct, 1));
+    void autoRefund_notificationFailure_doesNotRollbackRefund() {
+        Product product1 = productRepository.save(new Product("알림실패 상품1", ProductType.READY_STOCK, 45000L));
+        Product product2 = productRepository.save(new Product("알림실패 상품2", ProductType.READY_STOCK, 55000L));
+        inventoryRepository.save(new Inventory(product1, 1));
+        inventoryRepository.save(new Inventory(product2, 1));
 
         LocalDateTime paidAt = LocalDateTime.now(clock).minusHours(25);
 
-        Order failedOrder = orderRepository.save(new Order(null, 45000L, paidAt, paidAt.plusHours(24)));
-        orderItemRepository.save(new OrderItem(failedOrder, failedProduct.getId(), 1, 45000L));
-        inventoryRepository.findByProductId(failedProduct.getId()).ifPresent(inv -> {
+        Order order1 = orderRepository.save(new Order(null, 45000L, paidAt, paidAt.plusHours(24)));
+        orderItemRepository.save(new OrderItem(order1, product1.getId(), 1, 45000L));
+        inventoryRepository.findByProductId(product1.getId()).ifPresent(inv -> {
             inv.deduct(1);
             inventoryRepository.save(inv);
         });
 
-        Order successOrder = orderRepository.save(new Order(null, 55000L, paidAt, paidAt.plusHours(24)));
-        orderItemRepository.save(new OrderItem(successOrder, successProduct.getId(), 1, 55000L));
-        inventoryRepository.findByProductId(successProduct.getId()).ifPresent(inv -> {
+        Order order2 = orderRepository.save(new Order(null, 55000L, paidAt, paidAt.plusHours(24)));
+        orderItemRepository.save(new OrderItem(order2, product2.getId(), 1, 55000L));
+        inventoryRepository.findByProductId(product2.getId()).ifPresent(inv -> {
             inv.deduct(1);
             inventoryRepository.save(inv);
         });
 
+        // 첫 번째 주문의 알림만 실패
         doThrow(new RuntimeException("알림 전송 실패"))
                 .doNothing()
                 .when(notificationService)
@@ -309,14 +310,14 @@ class OrderApprovalUseCaseIT {
 
         BatchResult result = orderAutoRefundBatchService.autoRefundExpired();
 
-        assertThat(result.successCount()).isEqualTo(1);
-        assertThat(result.failureCount()).isEqualTo(1);
-        assertThat(result.failureReasons()).containsEntry("RuntimeException", 1);
+        // 알림 실패와 무관하게 두 건 모두 환불 성공
+        assertThat(result.successCount()).isEqualTo(2);
+        assertThat(result.failureCount()).isZero();
 
-        Order failedUpdated = orderRepository.findById(failedOrder.getId()).orElseThrow();
-        Order successUpdated = orderRepository.findById(successOrder.getId()).orElseThrow();
+        Order updated1 = orderRepository.findById(order1.getId()).orElseThrow();
+        Order updated2 = orderRepository.findById(order2.getId()).orElseThrow();
 
-        assertThat(failedUpdated.getStatus()).isEqualTo(OrderStatus.PAID_APPROVAL_PENDING);
-        assertThat(successUpdated.getStatus()).isEqualTo(OrderStatus.AUTO_REFUNDED_TIMEOUT);
+        assertThat(updated1.getStatus()).isEqualTo(OrderStatus.AUTO_REFUNDED_TIMEOUT);
+        assertThat(updated2.getStatus()).isEqualTo(OrderStatus.AUTO_REFUNDED_TIMEOUT);
     }
 }

--- a/docs/1Pager/0001_code_review_plan/codex-plan.md
+++ b/docs/1Pager/0001_code_review_plan/codex-plan.md
@@ -1,274 +1,271 @@
-# Code Review Plan
+# Code Review Plan (Unit-driven)
 
-## 목적
-- MVP 구현 이후 출시 전 리스크를 빠르게 식별한다.
-- 스타일보다 동작 버그, 스펙 불일치, 데이터 정합성, 테스트 누락을 우선 검토한다.
+## 1) 목적
+- 출시 전 리뷰를 "작업 단위"로 쪼개서, 한 번에 한 주제만 정확히 검토한다.
+- 스타일보다 동작 버그, 스펙 불일치, 데이터 정합성, 테스트 누락을 우선한다.
 
-## 리뷰 기준 문서
-- 기준 스펙: `docs/PRD/0001_spec/spec.md`
-- 설계 판단 참고: `docs/ADR/*`
+## 2) 기준 문서
+- 스펙: `docs/PRD/0001_spec/spec.md`
+- 설계 판단: `docs/ADR/*`
+- 작업 인수인계: `HANDOFF.md`
 
-## 리뷰 순서
-1. 변경 범위 정리
-- 포맷, 줄바꿈, 문서 전체 재기록처럼 기능과 무관한 diff를 먼저 분리한다.
-- 기능 변경 PR은 리뷰 가능한 단위로 유지한다.
-- 하나의 PR에 기능 변경, 테스트 인프라 정리, 문서/규칙 변경, 환경 설정 변경이 함께 섞이면 먼저 리뷰 묶음을 다시 나눈다.
-- 리뷰 묶음은 "하나의 사용자/운영 시나리오" 또는 "하나의 기술적 의도" 기준으로 자른다.
-- 아래 유형은 가능하면 별도 PR 또는 별도 리뷰 단위로 분리한다.
-  - 핵심 도메인 기능 변경: 상태 전이, 정책, 배치 처리, DB 마이그레이션
-  - API 계약 변경: 요청/응답 DTO, 에러 포맷, 직렬화 필드명
-  - 테스트 인프라 변경: `@UseCaseIT`, `MockMvc`, Testcontainers 설정, 공통 픽스처
-  - 문서/작업 규칙 변경: PRD, ADR, `AGENTS.md`, `HANDOFF.md`
-  - 환경/도구 변경: `.gitignore`, Gradle 의존성, 로깅/스케줄링 공통 설정
+## 3) 사용 규칙
+- 한 번의 지시는 `단위 1개`만 선택한다.
+- 산출물은 아래 3가지만 요청한다.
+  - `머지 전 수정 필요`
+  - `후속 이슈`
+  - `테스트/리스크`
+- 단위 완료 후 다음 단위로 넘어간다.
+- 큰 범위를 "전체 리뷰"로 한 번에 요청하지 않는다.
 
-### 현재 저장소 기준 권장 리뷰 단위
-1. 주문 승인/자동환불/픽업 만료 정합성
-- 대상: 낙관적 락, 재시도, 배치 건별 처리, 주문 승인 이력, version migration
-- 대표 파일:
-  - `app/src/main/java/com/personal/happygallery/app/order/*`
-  - `domain/src/main/java/com/personal/happygallery/domain/order/*`
-  - `app/src/main/resources/db/migration/V6__add_order_version_columns.sql`
-
-2. 배치 공통화와 운영 응답 계약
-- 대상: `BatchJob`, `BatchLoggingAspect`, `BatchResult`, 관리자 배치 DTO 응답
-- 대표 파일:
-  - `app/src/main/java/com/personal/happygallery/app/batch/*`
-  - `app/src/main/java/com/personal/happygallery/app/web/admin/*`
-  - `app/src/main/java/com/personal/happygallery/app/web/admin/dto/*`
-
-3. 8회권 만료/알림 동작 수정
-- 대상: 만료 시간 계산, 7일 전 알림, 중복 발송 방지, 관련 알림 로그 조회
-- 대표 파일:
-  - `app/src/main/java/com/personal/happygallery/app/pass/*`
-  - `infra/src/main/java/com/personal/happygallery/infra/notification/*`
-
-4. 테스트 보강
-- 대상: 회귀 테스트 추가, DTO 응답 계약 검증, 경쟁 조건/실패 경로 보강
-- 대표 파일:
-  - `app/src/test/java/com/personal/happygallery/app/order/*`
-  - `app/src/test/java/com/personal/happygallery/app/pass/*`
-  - `app/src/test/java/com/personal/happygallery/app/booking/*`
-
-5. 테스트 인프라/작업 규칙 정리
-- 대상: `@UseCaseIT`, `MockMvc` 공통 설정, `AGENTS.md`, `.gitignore`
-- 이 묶음은 기능 PR과 분리해서 마지막에 리뷰한다.
-
-## 실제 리뷰 진행 단위
-
-### 공통 원칙
-- 한 번의 리뷰 지시는 1개 주제, 최대 3~6개 파일 범위로 제한한다.
-- 한 번의 리뷰 결과는 `머지 전 수정 필요`, `후속 이슈`, `테스트/리스크` 3종으로만 받는다.
-- 다음 지시로 넘어가기 전에 이전 리뷰에서 확인한 파일 범위와 남은 의문점을 짧게 정리한다.
-- 큰 범위를 한 번에 "전체 리뷰"하지 않는다. 먼저 파일 범위와 관점을 고정한 뒤 세부 리뷰로 들어간다.
-
-### 추천 지시 형식
-- 범위 지정: 어떤 파일/기능만 볼지 명시한다.
-- 관점 지정: 스펙, 정합성, 레이어, API, 테스트 중 무엇을 볼지 명시한다.
-- 산출물 지정: "버그 중심", "리스크 중심", "테스트 누락 중심" 중 하나를 명시한다.
+## 4) 지시 템플릿
+`codex-plan [단위ID]만 진행해줘. [관점] 기준으로 보고, 결과는 머지 전 수정 필요/후속 이슈/테스트·리스크 형식으로 줘.`
 
 예시:
-- "`PLAN.md` 기준 1-1 범위만 리뷰해줘. 주문 승인 상태 전이와 승인 이력 저장 로직에서 머지 전 수정이 필요한 버그만 찾아줘."
-- "`PLAN.md` 기준 2-2 범위만 리뷰해줘. 관리자 배치 API 응답 DTO와 스펙 문서가 불일치하는 부분만 찾아줘."
-- "`PLAN.md` 기준 4-1 범위만 리뷰해줘. 추가된 테스트가 실제 변경을 충분히 막는지 테스트 누락 중심으로 봐줘."
+- `codex-plan U2만 진행해줘. 정합성과 중복 처리 위험 중심으로 보고, 결과는 3분류로 줘.`
+- `codex-plan U6만 진행해줘. API 계약과 정보 노출 범위만 집중해서 봐줘.`
 
-## 세부 리뷰 태스크
+## 5) 단위 목록 (우선순위)
+- P0: U1, U2, U3, U4, U6
+- P1: U5, U8, U9, U10, U11
+- P2: U7, U12
 
-### 1. 주문 승인/자동환불/픽업 만료 정합성
+---
 
-#### 1-1. 주문 승인 상태 전이와 승인 이력
-- 파일 범위:
-  - `app/src/main/java/com/personal/happygallery/app/order/OrderApprovalService.java`
-  - `domain/src/main/java/com/personal/happygallery/domain/order/Order.java`
-  - `domain/src/main/java/com/personal/happygallery/domain/order/OrderApprovalHistory.java`
-  - `domain/src/main/java/com/personal/happygallery/domain/order/OrderApprovalDecision.java`
-  - `infra/src/main/java/com/personal/happygallery/infra/order/OrderApprovalHistoryRepository.java`
-- 확인 포인트:
-  - 승인/거절 상태 전이가 스펙과 맞는지
-  - 승인 이력이 누락되거나 중복 저장될 수 없는지
-  - 주문 상태와 이력의 원자성이 깨지지 않는지
-- 지시 예시:
-  - "`PLAN.md` 기준 1-1만 리뷰해줘. 주문 승인/거절 상태 전이와 승인 이력 저장에 머지 전 수정이 필요한 버그가 있는지 봐줘."
+## U1. 주문 승인/거절 상태 전이 + 승인 이력
+### 범위
+- `app/src/main/java/com/personal/happygallery/app/order/OrderApprovalService.java`
+- `domain/src/main/java/com/personal/happygallery/domain/order/Order.java`
+- `domain/src/main/java/com/personal/happygallery/domain/order/OrderApprovalHistory.java`
+- `domain/src/main/java/com/personal/happygallery/domain/order/OrderApprovalDecision.java`
+- `infra/src/main/java/com/personal/happygallery/infra/order/OrderApprovalHistoryRepository.java`
 
-#### 1-2. 자동환불 배치 처리와 건별 트랜잭션
-- 파일 범위:
-  - `app/src/main/java/com/personal/happygallery/app/order/OrderAutoRefundBatchService.java`
-  - `app/src/main/java/com/personal/happygallery/app/order/OrderAutoRefundProcessor.java`
-- 확인 포인트:
-  - 목록 조회 후 건별 처리에서 누락/중복 처리 가능성이 없는지
-  - 실패 건이 전체 배치를 망치지 않는지
-  - 성공/실패 집계가 실제 처리 결과와 어긋나지 않는지
-- 지시 예시:
-  - "`PLAN.md` 기준 1-2만 리뷰해줘. 주문 자동환불 배치가 중복 환불이나 누락 처리 위험이 없는지 정합성 중심으로 봐줘."
+### 확인 포인트
+- 승인/거절 상태 전이가 스펙과 일치하는지
+- 승인 이력 누락/중복 가능성이 없는지
+- 주문 상태 변경과 이력 저장의 원자성이 깨지지 않는지
 
-#### 1-3. 픽업 만료 배치 처리와 환불/재고 복구
-- 파일 범위:
-  - `app/src/main/java/com/personal/happygallery/app/order/PickupExpireBatchService.java`
-  - `app/src/main/java/com/personal/happygallery/app/order/PickupExpireProcessor.java`
-  - `app/src/main/java/com/personal/happygallery/app/order/OrderPickupService.java`
-  - `domain/src/main/java/com/personal/happygallery/domain/order/Fulfillment.java`
-- 확인 포인트:
-  - 픽업 준비, 픽업 완료, 픽업 만료 상태 전이 충돌이 없는지
-  - 재고 복구/환불/fulfillment 상태 동기화가 항상 같이 움직이는지
-  - 수동 픽업 완료와 배치 만료가 동시에 일어날 때 안전한지
-- 지시 예시:
-  - "`PLAN.md` 기준 1-3만 리뷰해줘. 픽업 만료 배치와 수동 픽업 완료가 충돌할 때 데이터 정합성 문제가 없는지 찾아줘."
+### 완료 조건
+- 상태 전이 버그/이력 정합성 리스크를 식별하고 우선순위를 제시했다.
 
-#### 1-4. 낙관적 락, 재시도, version migration
-- 파일 범위:
-  - `domain/src/main/java/com/personal/happygallery/domain/order/Order.java`
-  - `domain/src/main/java/com/personal/happygallery/domain/order/Fulfillment.java`
-  - `app/src/main/resources/db/migration/V6__add_order_version_columns.sql`
-  - `app/src/main/java/com/personal/happygallery/config/RetryConfig.java`
-- 확인 포인트:
-  - `@Version` 적용 위치와 migration이 일치하는지
-  - 재시도 정책이 과도하거나 부족하지 않은지
-  - version 기본값/기존 데이터 migration이 안전한지
-- 지시 예시:
-  - "`PLAN.md` 기준 1-4만 리뷰해줘. version 컬럼 migration과 낙관적 락 설정에 운영 리스크가 있는지 봐줘."
+### 최소 검증 명령
+- `GRADLE_USER_HOME=/tmp/.gradle ./gradlew --no-daemon :app:test --tests com.personal.happygallery.app.order.OrderApprovalUseCaseIT`
 
-### 2. 배치 공통화와 운영 응답 계약
+---
 
-#### 2-1. 배치 공통 로깅/AOP
-- 파일 범위:
-  - `app/src/main/java/com/personal/happygallery/app/batch/BatchJob.java`
-  - `app/src/main/java/com/personal/happygallery/app/batch/BatchLoggingAspect.java`
-  - `app/src/main/java/com/personal/happygallery/app/batch/BatchScheduler.java`
-- 확인 포인트:
-  - 로깅이 예외를 삼키지 않는지
-  - 스케줄러 반환값/예외와 AOP 로그가 어긋나지 않는지
-  - 공통화로 인해 개별 배치 의미가 가려지지 않는지
-- 지시 예시:
-  - "`PLAN.md` 기준 2-1만 리뷰해줘. 배치 AOP 공통화가 예외 처리나 로그 정확도를 깨지 않는지 봐줘."
+## U2. 주문 자동환불 배치 건별 처리
+### 범위
+- `app/src/main/java/com/personal/happygallery/app/order/OrderAutoRefundBatchService.java`
+- `app/src/main/java/com/personal/happygallery/app/order/OrderAutoRefundProcessor.java`
 
-#### 2-2. BatchResult와 관리자 배치 API 응답
-- 파일 범위:
-  - `app/src/main/java/com/personal/happygallery/app/batch/BatchResult.java`
-  - `app/src/main/java/com/personal/happygallery/app/web/admin/AdminOrderController.java`
-  - `app/src/main/java/com/personal/happygallery/app/web/admin/AdminPassController.java`
-  - `app/src/main/java/com/personal/happygallery/app/web/admin/dto/BatchResponse.java`
-- 확인 포인트:
-  - 내부 결과와 외부 응답 DTO 책임이 잘 분리됐는지
-  - 필드명/직렬화/빈 맵 응답이 스펙과 충돌하지 않는지
-  - 실패 사유 정보가 과소/과대 노출되는지
-- 지시 예시:
-  - "`PLAN.md` 기준 2-2만 리뷰해줘. BatchResult와 BatchResponse 분리가 적절한지 API 계약 중심으로 봐줘."
+### 확인 포인트
+- 건별 실패가 전체 배치를 중단시키지 않는지
+- 중복 환불/누락 처리 가능성이 없는지
+- 성공/실패 집계가 실제 결과와 일치하는지
 
-#### 2-3. 관리자 부수 응답 DTO 정리
-- 파일 범위:
-  - `app/src/main/java/com/personal/happygallery/app/web/admin/AdminBookingController.java`
-  - `app/src/main/java/com/personal/happygallery/app/web/admin/AdminRefundController.java`
-  - `app/src/main/java/com/personal/happygallery/app/web/admin/dto/BookingNoShowResponse.java`
-  - `app/src/main/java/com/personal/happygallery/app/web/admin/dto/FailedRefundResponse.java`
-- 확인 포인트:
-  - 기존 `Map` 응답을 DTO로 바꾸며 계약 회귀가 없는지
-  - nullable 필드 매핑이 안전한지
-  - 운영자 화면이 의존할 필드가 빠지지 않았는지
-- 지시 예시:
-  - "`PLAN.md` 기준 2-3만 리뷰해줘. AdminBooking/AdminRefund 응답 DTO 전환에 회귀 위험이 없는지 찾아줘."
+### 완료 조건
+- 배치 정합성 관점의 치명/중요 리스크를 분류했다.
 
-### 3. 8회권 만료/알림 동작 수정
+### 최소 검증 명령
+- `GRADLE_USER_HOME=/tmp/.gradle ./gradlew --no-daemon :app:test --tests com.personal.happygallery.app.order.OrderApprovalUseCaseIT`
 
-#### 3-1. 8회권 만료 배치
-- 파일 범위:
-  - `app/src/main/java/com/personal/happygallery/app/pass/PassExpiryBatchService.java`
-- 확인 포인트:
-  - 만료 처리 시 크레딧 차감/ledger 기록이 정확한지
-  - 이미 만료된 pass를 중복 처리하지 않는지
-  - 성공 건수와 실제 갱신 건수가 일치하는지
-- 지시 예시:
-  - "`PLAN.md` 기준 3-1만 리뷰해줘. 8회권 만료 배치가 중복 만료나 ledger 오류를 만들 수 있는지 봐줘."
+---
 
-#### 3-2. 만료 7일 전 알림과 중복 발송 방지
-- 파일 범위:
-  - `app/src/main/java/com/personal/happygallery/app/pass/PassExpiryBatchService.java`
-  - `infra/src/main/java/com/personal/happygallery/infra/notification/NotificationLogRepository.java`
-- 확인 포인트:
-  - 정확히 7일 전 조건이 스펙과 일치하는지
-  - 하루 1회만 발송된다는 보장이 실제로 되는지
-  - 실패 시 재시도/누락 리스크가 있는지
-- 지시 예시:
-  - "`PLAN.md` 기준 3-2만 리뷰해줘. 만료 알림이 하루 1회, 7일 전 조건을 정확히 지키는지 봐줘."
+## U3. 픽업 만료 배치 + 수동 픽업 완료 충돌
+### 범위
+- `app/src/main/java/com/personal/happygallery/app/order/PickupExpireBatchService.java`
+- `app/src/main/java/com/personal/happygallery/app/order/PickupExpireProcessor.java`
+- `app/src/main/java/com/personal/happygallery/app/order/OrderPickupService.java`
+- `domain/src/main/java/com/personal/happygallery/domain/order/Fulfillment.java`
 
-### 4. 테스트 보강
+### 확인 포인트
+- `PICKUP_READY -> PICKED_UP / PICKUP_EXPIRED_REFUNDED` 충돌 시 안전한지
+- 환불/재고/fulfillment 상태가 원자적으로 맞물리는지
+- 동시 실행 시 중복 상태 전이 위험이 없는지
 
-#### 4-1. 주문/배치 회귀 테스트
-- 파일 범위:
-  - `app/src/test/java/com/personal/happygallery/app/order/*`
-- 확인 포인트:
-  - 승인 이력, 자동환불, 픽업 만료의 핵심 회귀가 잡히는지
-  - 실패 경로와 동시성 경로가 충분한지
-- 지시 예시:
-  - "`PLAN.md` 기준 4-1만 리뷰해줘. 주문/배치 관련 테스트가 실제 회귀를 막기에 충분한지 테스트 누락 중심으로 봐줘."
+### 완료 조건
+- 경합 시나리오 기준 회귀 위험 여부를 판정했다.
 
-#### 4-2. 패스/알림/관리자 응답 테스트
-- 파일 범위:
-  - `app/src/test/java/com/personal/happygallery/app/pass/*`
-  - `app/src/test/java/com/personal/happygallery/app/booking/BookingCancelUseCaseIT.java`
-- 확인 포인트:
-  - 응답 DTO 계약 검증이 핵심 필드를 다 막는지
-  - 만료/알림 관련 경계값 테스트가 충분한지
-- 지시 예시:
-  - "`PLAN.md` 기준 4-2만 리뷰해줘. 패스 만료/알림과 관리자 응답 DTO 테스트가 충분한지 봐줘."
+### 최소 검증 명령
+- `GRADLE_USER_HOME=/tmp/.gradle ./gradlew --no-daemon :app:test --tests com.personal.happygallery.app.order.PickupExpireBatchUseCaseIT`
 
-### 5. 테스트 인프라/작업 규칙 정리
+---
 
-#### 5-1. UseCaseIT와 MockMvc 공통 설정
-- 파일 범위:
-  - `app/src/test/java/com/personal/happygallery/support/UseCaseIT.java`
-  - 관련 `*UseCaseIT`
-- 확인 포인트:
-  - 공통 설정 변경이 기존 테스트 의미를 바꾸지 않는지
-  - 필터 적용 여부가 테스트 의도와 맞는지
-- 지시 예시:
-  - "`PLAN.md` 기준 5-1만 리뷰해줘. UseCaseIT의 MockMvc 공통화가 테스트 의미를 바꾸지 않는지 봐줘."
+## U4. 낙관적 락 + 재시도 정책 + 마이그레이션
+### 범위
+- `domain/src/main/java/com/personal/happygallery/domain/order/Order.java`
+- `domain/src/main/java/com/personal/happygallery/domain/order/Fulfillment.java`
+- `app/src/main/java/com/personal/happygallery/config/RetryConfig.java`
+- `app/src/main/resources/db/migration/V6__add_order_version_columns.sql`
 
-#### 5-2. 작업 규칙/환경 파일 정리
-- 파일 범위:
-  - `AGENTS.md`
-  - `.gitignore`
-- 확인 포인트:
-  - 기능 변경과 분리해서 볼 가치가 있는지
-  - 저장소 운영 규칙으로 적절한지
-- 지시 예시:
-  - "`PLAN.md` 기준 5-2만 리뷰해줘. AGENTS.md와 gitignore 변경이 저장소 운영 규칙으로 적절한지만 봐줘."
+### 확인 포인트
+- `@Version`과 DDL이 실제로 일치하는지
+- 재시도 횟수/백오프가 과도하거나 부족하지 않은지
+- 기존 데이터/운영 배포 관점에서 migration이 안전한지
 
-2. 스펙 일치성 검토
-- 상태값, 시간 경계, 예약금 10%, 슬롯 정원 8명, 버퍼 30분, 8회권 90일 만료 규칙이 스펙과 일치하는지 확인한다.
-- 구현 변경이 스펙 변경을 동반하면 문서도 함께 갱신했는지 확인한다.
+### 완료 조건
+- 락/재시도/DDL의 불일치 여부를 확정했다.
 
-3. 레이어 책임 검토
-- `app`은 흐름 제어에 집중하고, 도메인 규칙은 `domain`에, 외부 연동 구현은 `infra`에 유지되는지 확인한다.
-- `app`에 정책이 과도하게 들어가거나 `infra`에 업무 규칙이 들어가지 않았는지 본다.
+### 최소 검증 명령
+- `GRADLE_USER_HOME=/tmp/.gradle ./gradlew --no-daemon :app:compileJava :app:compileTestJava`
 
-4. 핵심 도메인 리뷰
-- 예약/슬롯: 예약 생성, 변경, 취소, 정원 초과, 버퍼 비활성화, 중복 예약 방지
-- 주문/환불: 승인 대기, 자동 환불, 재고 복구, 픽업 만료, 제작 시작 후 환불 불가
-- 8회권: 결제, 차감, 만료, 환불, 미래 예약 취소
+---
 
-5. 정합성과 동시성 검토
-- 재고와 슬롯은 트랜잭션 안에서 일관되게 갱신되는지 확인한다.
-- 수동 처리와 배치가 동시에 실행될 때 중복 환불, 중복 차감, 중복 상태 전이가 없는지 본다.
+## U5. 배치 공통 로깅 AOP
+### 범위
+- `app/src/main/java/com/personal/happygallery/app/batch/BatchJob.java`
+- `app/src/main/java/com/personal/happygallery/app/batch/BatchLoggingAspect.java`
+- `app/src/main/java/com/personal/happygallery/app/batch/BatchScheduler.java`
 
-6. API/예외/알림 검토
-- 요청/응답 DTO와 에러 포맷이 일관적인지 확인한다.
-- 외부 연동 실패 시 상태 기록과 재시도 경로가 남는지 확인한다.
+### 확인 포인트
+- AOP가 예외를 삼키지 않는지
+- 로그 메시지가 실제 실행 결과를 왜곡하지 않는지
+- 배치명 fallback 규칙이 운영 식별에 충분한지
 
-7. 테스트 검토
-- 정책 변경은 `policyTest`, 유스케이스/DB 영향은 `useCaseTest`가 따라오는지 확인한다.
-- 경계값, 실패 경로, 경쟁 조건 테스트가 있는지 검토한다.
+### 완료 조건
+- 로그 정확성/관측성 리스크를 정리했다.
 
-## 우선 리뷰 대상
-- `app/src/main/java/com/personal/happygallery/app/booking/*`
-- `app/src/main/java/com/personal/happygallery/app/order/*`
-- `app/src/main/java/com/personal/happygallery/app/pass/*`
-- `domain/src/main/java/com/personal/happygallery/domain/booking/*`
-- `domain/src/main/java/com/personal/happygallery/domain/order/*`
-- `domain/src/main/java/com/personal/happygallery/domain/pass/*`
-- `common/src/main/java/com/personal/happygallery/common/time/TimeBoundary.java`
-- `app/src/main/resources/db/migration/*`
-- 관련 `*UseCaseIT`, `*PolicyTest`
+### 최소 검증 명령
+- `GRADLE_USER_HOME=/tmp/.gradle ./gradlew --no-daemon :app:test --tests com.personal.happygallery.app.batch.BatchLoggingAspectTest`
 
-## 리뷰 산출물
-- 머지 전 반드시 수정할 이슈
-- 후속 이슈로 넘길 개선 항목
-- 실행한 테스트와 남은 리스크
+---
+
+## U6. BatchResult + BatchResponse API 계약
+### 범위
+- `app/src/main/java/com/personal/happygallery/app/batch/BatchResult.java`
+- `app/src/main/java/com/personal/happygallery/app/web/admin/dto/BatchResponse.java`
+- `app/src/main/java/com/personal/happygallery/app/web/admin/AdminOrderController.java`
+- `app/src/main/java/com/personal/happygallery/app/web/admin/AdminPassController.java`
+- `docs/PRD/0001_spec/spec.md` (11-F.3, 11-G.1)
+
+### 확인 포인트
+- 내부 결과 모델과 외부 응답 DTO 책임 분리가 적절한지
+- `failureReasons`가 스펙 계약과 일치하는지
+- 내부 예외 정보 과다 노출/과소 노출 리스크가 없는지
+
+### 완료 조건
+- API 계약 불일치 여부와 수정 우선순위를 확정했다.
+
+### 최소 검증 명령
+- `GRADLE_USER_HOME=/tmp/.gradle ./gradlew --no-daemon :app:test --tests com.personal.happygallery.app.batch.BatchResultTest --tests com.personal.happygallery.app.web.admin.dto.BatchResponseTest`
+
+---
+
+## U7. Admin 보조 DTO (NoShow/FailedRefund)
+### 범위
+- `app/src/main/java/com/personal/happygallery/app/web/admin/AdminBookingController.java`
+- `app/src/main/java/com/personal/happygallery/app/web/admin/AdminRefundController.java`
+- `app/src/main/java/com/personal/happygallery/app/web/admin/dto/BookingNoShowResponse.java`
+- `app/src/main/java/com/personal/happygallery/app/web/admin/dto/FailedRefundResponse.java`
+- `docs/PRD/0001_spec/spec.md` (11-H)
+
+### 확인 포인트
+- DTO 전환 시 기존 계약 회귀가 없는지
+- nullable 필드(`bookingId`, `orderId`) 매핑이 안전한지
+- 운영자가 필요한 필드가 빠지지 않았는지
+
+### 완료 조건
+- 계약 회귀/널 처리 이슈를 분류했다.
+
+### 최소 검증 명령
+- `GRADLE_USER_HOME=/tmp/.gradle ./gradlew --no-daemon :app:test --tests com.personal.happygallery.app.booking.BookingCancelUseCaseIT`
+
+---
+
+## U8. 8회권 만료 배치
+### 범위
+- `app/src/main/java/com/personal/happygallery/app/pass/PassExpiryBatchService.java`
+
+### 확인 포인트
+- 만료 시 크레딧/ledger 기록이 정확한지
+- 중복 만료 처리 위험이 없는지
+- 성공 건수와 실제 반영 건수가 일치하는지
+
+### 완료 조건
+- 만료 배치 정합성 리스크를 확정했다.
+
+### 최소 검증 명령
+- `GRADLE_USER_HOME=/tmp/.gradle ./gradlew --no-daemon :app:test --tests com.personal.happygallery.app.pass.PassPurchaseUseCaseIT`
+
+---
+
+## U9. 만료 7일 전 알림 + 중복 발송 방지
+### 범위
+- `app/src/main/java/com/personal/happygallery/app/pass/PassExpiryBatchService.java`
+- `infra/src/main/java/com/personal/happygallery/infra/notification/NotificationLogRepository.java`
+
+### 확인 포인트
+- 7일 전 조건 계산이 스펙과 일치하는지
+- 동일 대상 하루 1회 보장이 되는지
+- 실패/재시도 시 누락 리스크가 없는지
+
+### 완료 조건
+- 알림 중복/누락 리스크를 분류했다.
+
+### 최소 검증 명령
+- `GRADLE_USER_HOME=/tmp/.gradle ./gradlew --no-daemon :app:test --tests com.personal.happygallery.app.pass.PassExpiryNotificationUseCaseIT`
+
+---
+
+## U10. 주문/배치 회귀 테스트 충분성
+### 범위
+- `app/src/test/java/com/personal/happygallery/app/order/*`
+
+### 확인 포인트
+- 승인/자동환불/픽업만료 핵심 시나리오가 커버되는지
+- 실패 경로/경합 경로 테스트가 충분한지
+
+### 완료 조건
+- 테스트 누락 목록과 추가 우선순위를 제시했다.
+
+### 최소 검증 명령
+- `GRADLE_USER_HOME=/tmp/.gradle ./gradlew --no-daemon :app:test --tests com.personal.happygallery.app.order.OrderApprovalUseCaseIT --tests com.personal.happygallery.app.order.PickupExpireBatchUseCaseIT --tests com.personal.happygallery.app.order.OrderProductionUseCaseIT`
+
+---
+
+## U11. 패스/예약 환불/Admin 응답 테스트 충분성
+### 범위
+- `app/src/test/java/com/personal/happygallery/app/pass/*`
+- `app/src/test/java/com/personal/happygallery/app/booking/BookingCancelUseCaseIT.java`
+
+### 확인 포인트
+- DTO 계약 검증이 핵심 필드를 막는지
+- 경계값/예외 경로 검증이 충분한지
+
+### 완료 조건
+- 테스트 보강 필요 지점을 시나리오 단위로 정리했다.
+
+### 최소 검증 명령
+- `GRADLE_USER_HOME=/tmp/.gradle ./gradlew --no-daemon :app:test --tests com.personal.happygallery.app.booking.BookingCancelUseCaseIT --tests com.personal.happygallery.app.pass.PassCreditUsageUseCaseIT --tests com.personal.happygallery.app.pass.PassPurchaseUseCaseIT`
+
+---
+
+## U12. 테스트 인프라/저장소 운영 규칙
+### 범위
+- `app/src/test/java/com/personal/happygallery/support/UseCaseIT.java`
+- `AGENTS.md`
+- `.gitignore`
+
+### 확인 포인트
+- 공통 테스트 설정이 테스트 의미를 바꾸지 않는지
+- 운영 규칙 문서가 실제 워크플로우와 맞는지
+
+### 완료 조건
+- 규칙/인프라 변경을 기능 변경과 분리해 판단했다.
+
+### 최소 검증 명령
+- 필요 시 관련 테스트 최소셋만 선택 실행
+
+---
+
+## 6) 리뷰 응답 형식 고정
+- `머지 전 수정 필요`
+- `후속 이슈`
+- `테스트/리스크`
+
+## 7) 단위 선택 가이드
+- 배치/환불 동작이 의심되면: `U2`, `U3`, `U6`
+- 상태 전이/도메인 규칙이 의심되면: `U1`, `U4`
+- 알림/8회권이 의심되면: `U8`, `U9`
+- 테스트 충분성이 의심되면: `U10`, `U11`
+- 규칙/환경 문서 점검은 마지막에: `U12`

--- a/docs/PRD/0001_spec/spec.md
+++ b/docs/PRD/0001_spec/spec.md
@@ -207,7 +207,8 @@
 - `order_items`
     - id, order_id, product_id, qty, unit_price
 - `order_approvals`
-    - id, order_id, decided_by_admin_id, decision(APPROVE|REJECT|DELAY), reason, decided_at
+    - id, order_id, decided_by_admin_id, decision(APPROVE|REJECT|DELAY|AUTO_REFUND), reason, decided_at
+    - `AUTO_REFUND`는 배치 결정 이력이며 `decided_by_admin_id`는 null일 수 있음
 - `fulfillments`
     - id, order_id, type(SHIPPING|PICKUP), status, address/pickup_store, expected_ship_date, pickup_deadline_at, version
 - `refunds`

--- a/domain/src/main/java/com/personal/happygallery/domain/order/OrderApprovalDecision.java
+++ b/domain/src/main/java/com/personal/happygallery/domain/order/OrderApprovalDecision.java
@@ -3,5 +3,6 @@ package com.personal.happygallery.domain.order;
 public enum OrderApprovalDecision {
     APPROVE,
     REJECT,
-    DELAY
+    DELAY,
+    AUTO_REFUND
 }

--- a/domain/src/main/java/com/personal/happygallery/domain/order/OrderApprovalHistory.java
+++ b/domain/src/main/java/com/personal/happygallery/domain/order/OrderApprovalHistory.java
@@ -25,7 +25,7 @@ public class OrderApprovalHistory {
     private Long decidedByAdminId;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 10)
+    @Column(nullable = false, length = 20)
     private OrderApprovalDecision decision;
 
     @Column(length = 500)


### PR DESCRIPTION
## 작업 배경
- 주문 상태/승인 이력(`order-state-approval-history`) 작업을 위한 전용 브랜치를 생성합니다.

## 변경 사항
- 작업 브랜치 생성 및 원격 푸시
- Draft PR 생성
- 코드 변경은 아직 포함하지 않음 (empty commit 1개)

## 다음 단계
- 주문 상태 전이 및 승인 이력 관련 변경을 단위별로 커밋하여 본 PR에 반영 예정