### PR TITLE
Feat: work-cc 후속 반영 (배치/환불/제작흐름)

### DIFF
--- a/app/src/main/java/com/personal/happygallery/app/order/OrderApprovalService.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/OrderApprovalService.java
@@ -89,6 +89,10 @@ public class OrderApprovalService {
      * @param orderId 주문 ID
      * @return 승인된 주문
      */
+    public Order approve(Long orderId) {
+        return approve(orderId, null);
+    }
+
     @Retryable(
             retryFor = ObjectOptimisticLockingFailureException.class,
             maxAttempts = RetryConfig.OPTIMISTIC_LOCK_MAX_ATTEMPTS,
@@ -96,7 +100,7 @@ public class OrderApprovalService {
                     delay = RetryConfig.OPTIMISTIC_LOCK_INITIAL_DELAY_MILLIS,
                     multiplier = RetryConfig.OPTIMISTIC_LOCK_BACKOFF_MULTIPLIER,
                     random = true))
-    public Order approve(Long orderId) {
+    public Order approve(Long orderId, Long adminId) {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new NotFoundException("주문"));
 
@@ -108,7 +112,8 @@ public class OrderApprovalService {
         } else {
             order.approve();
         }
-        orderApprovalHistoryRepository.save(new OrderApprovalHistory(order.getId(), OrderApprovalDecision.APPROVE));
+        orderApprovalHistoryRepository.save(
+                new OrderApprovalHistory(order.getId(), OrderApprovalDecision.APPROVE, adminId, null));
         return orderRepository.save(order);
     }
 
@@ -136,6 +141,10 @@ public class OrderApprovalService {
      * @param orderId 주문 ID
      * @return 거절된 주문
      */
+    public Order reject(Long orderId) {
+        return reject(orderId, null);
+    }
+
     @Retryable(
             retryFor = ObjectOptimisticLockingFailureException.class,
             maxAttempts = RetryConfig.OPTIMISTIC_LOCK_MAX_ATTEMPTS,
@@ -143,14 +152,15 @@ public class OrderApprovalService {
                     delay = RetryConfig.OPTIMISTIC_LOCK_INITIAL_DELAY_MILLIS,
                     multiplier = RetryConfig.OPTIMISTIC_LOCK_BACKOFF_MULTIPLIER,
                     random = true))
-    public Order reject(Long orderId) {
+    public Order reject(Long orderId, Long adminId) {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new NotFoundException("주문"));
         order.reject();
 
         restoreInventory(order);
         processRefund(order);
-        orderApprovalHistoryRepository.save(new OrderApprovalHistory(order.getId(), OrderApprovalDecision.REJECT));
+        orderApprovalHistoryRepository.save(
+                new OrderApprovalHistory(order.getId(), OrderApprovalDecision.REJECT, adminId, null));
         notificationService.notifyByGuestId(order.getGuestId(), NotificationEventType.ORDER_REFUNDED);
 
         return orderRepository.save(order);

--- a/app/src/main/java/com/personal/happygallery/app/order/OrderProductionService.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/OrderProductionService.java
@@ -99,6 +99,34 @@ public class OrderProductionService {
         return new ProductionResult(order.getId(), order.getStatus(), fulfillment.getExpectedShipDate());
     }
 
+    /**
+     * 제작 완료 처리. {@link OrderStatus#IN_PRODUCTION} 또는 {@link OrderStatus#DELAY_REQUESTED}에서
+     * {@link OrderStatus#APPROVED_FULFILLMENT_PENDING}으로 전이한다.
+     * 이후 픽업 준비({@code markPickupReady}) 또는 배송 흐름으로 이어진다.
+     */
+    @Retryable(
+            retryFor = ObjectOptimisticLockingFailureException.class,
+            maxAttempts = RetryConfig.OPTIMISTIC_LOCK_MAX_ATTEMPTS,
+            backoff = @Backoff(
+                    delay = RetryConfig.OPTIMISTIC_LOCK_INITIAL_DELAY_MILLIS,
+                    multiplier = RetryConfig.OPTIMISTIC_LOCK_BACKOFF_MULTIPLIER,
+                    random = true))
+    public ProductionResult completeProduction(Long orderId, Long adminId) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new NotFoundException("주문"));
+        order.completeProduction();
+
+        Fulfillment fulfillment = fulfillmentRepository.findByOrderId(orderId)
+                .orElseThrow(() -> new NotFoundException("이행 정보"));
+        fulfillment.syncStatus(order.getStatus());
+        fulfillmentRepository.save(fulfillment);
+
+        orderApprovalHistoryRepository.save(
+                new OrderApprovalHistory(order.getId(), OrderApprovalDecision.PRODUCTION_COMPLETE, adminId, null));
+        orderRepository.save(order);
+        return new ProductionResult(order.getId(), order.getStatus(), fulfillment.getExpectedShipDate());
+    }
+
     /** 제작 관련 서비스 작업의 결과를 컨트롤러에 전달하는 내부 DTO. */
     public record ProductionResult(Long orderId, OrderStatus status, LocalDate expectedShipDate) {}
 }

--- a/app/src/main/java/com/personal/happygallery/app/pass/PassExpiryBatchService.java
+++ b/app/src/main/java/com/personal/happygallery/app/pass/PassExpiryBatchService.java
@@ -99,21 +99,27 @@ public class PassExpiryBatchService {
         LocalDateTime sentEnd = sentStart.plusDays(1);
         List<PassPurchase> expiring = passPurchaseRepository.findExpiringWithGuestBetween(targetStart, targetEnd);
         int notified = 0;
+        Map<String, Integer> failureReasons = new LinkedHashMap<>();
 
         for (PassPurchase pass : expiring) {
-            if (notificationLogRepository.existsByGuestIdAndEventTypeAndStatusAndSentAtBetween(
-                    pass.getGuest().getId(),
-                    NotificationEventType.PASS_EXPIRY_SOON,
-                    "SUCCESS",
-                    sentStart,
-                    sentEnd)) {
-                continue;
+            try {
+                if (notificationLogRepository.existsByGuestIdAndEventTypeAndStatusAndSentAtBetween(
+                        pass.getGuest().getId(),
+                        NotificationEventType.PASS_EXPIRY_SOON,
+                        "SUCCESS",
+                        sentStart,
+                        sentEnd)) {
+                    continue;
+                }
+                notificationService.notifyByGuestId(pass.getGuest().getId(), NotificationEventType.PASS_EXPIRY_SOON);
+                log.info("8회권 만료 7일 전 알림 발송 [passId={}, guestId={}]", pass.getId(), pass.getGuest().getId());
+                notified++;
+            } catch (Exception e) {
+                log.warn("8회권 만료 알림 실패 [passId={}, guestId={}]", pass.getId(), pass.getGuest().getId(), e);
+                failureReasons.merge(e.getClass().getSimpleName(), 1, Integer::sum);
             }
-            notificationService.notifyByGuestId(pass.getGuest().getId(), NotificationEventType.PASS_EXPIRY_SOON);
-            log.info("8회권 만료 7일 전 알림 발송 [passId={}, guestId={}]", pass.getId(), pass.getGuest().getId());
-            notified++;
         }
 
-        return BatchResult.successOnly(notified);
+        return BatchResult.of(notified, failureReasons);
     }
 }

--- a/app/src/main/java/com/personal/happygallery/app/web/admin/AdminOrderController.java
+++ b/app/src/main/java/com/personal/happygallery/app/web/admin/AdminOrderController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,6 +25,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/admin/orders")
 public class AdminOrderController {
+
+    private static final String ADMIN_ID_HEADER = "X-Admin-Id";
 
     private final OrderApprovalService orderApprovalService;
     private final OrderProductionService orderProductionService;
@@ -43,15 +46,27 @@ public class AdminOrderController {
     /** POST /admin/orders/{id}/approve — 주문 승인 (MADE_TO_ORDER는 IN_PRODUCTION으로 전이) */
     @PostMapping("/{id}/approve")
     @ResponseStatus(HttpStatus.OK)
-    public void approve(@PathVariable Long id) {
-        orderApprovalService.approve(id);
+    public void approve(@PathVariable Long id,
+                        @RequestHeader(value = ADMIN_ID_HEADER, required = false) Long adminId) {
+        orderApprovalService.approve(id, adminId);
     }
 
     /** POST /admin/orders/{id}/reject — 주문 거절 (환불 + 재고 복구 포함, 제작 중은 거절 불가) */
     @PostMapping("/{id}/reject")
     @ResponseStatus(HttpStatus.OK)
-    public void reject(@PathVariable Long id) {
-        orderApprovalService.reject(id);
+    public void reject(@PathVariable Long id,
+                       @RequestHeader(value = ADMIN_ID_HEADER, required = false) Long adminId) {
+        orderApprovalService.reject(id, adminId);
+    }
+
+    /** POST /admin/orders/{id}/complete-production — 제작 완료 (IN_PRODUCTION/DELAY_REQUESTED → APPROVED_FULFILLMENT_PENDING) */
+    @PostMapping("/{id}/complete-production")
+    @ResponseStatus(HttpStatus.OK)
+    public OrderProductionResponse completeProduction(
+            @PathVariable Long id,
+            @RequestHeader(value = ADMIN_ID_HEADER, required = false) Long adminId) {
+        ProductionResult result = orderProductionService.completeProduction(id, adminId);
+        return new OrderProductionResponse(result.orderId(), result.status(), result.expectedShipDate());
     }
 
     /** PATCH /admin/orders/{id}/expected-ship-date — 예상 출고일 설정/갱신 */

--- a/app/src/main/java/com/personal/happygallery/app/web/admin/dto/BatchResponse.java
+++ b/app/src/main/java/com/personal/happygallery/app/web/admin/dto/BatchResponse.java
@@ -10,10 +10,12 @@ public record BatchResponse(
         Map<String, Integer> failureReasons
 ) {
 
-    private static final Map<String, String> REASON_LABELS = Map.of(
-            "ObjectOptimisticLockingFailureException", "CONFLICT",
-            "OptimisticLockingFailureException", "CONFLICT",
-            "NotFoundException", "NOT_FOUND"
+    private static final Map<String, String> REASON_LABELS = Map.ofEntries(
+            Map.entry("ObjectOptimisticLockingFailureException", "CONFLICT"),
+            Map.entry("OptimisticLockingFailureException", "CONFLICT"),
+            Map.entry("NotFoundException", "NOT_FOUND"),
+            Map.entry("AlreadyRefundedException", "ALREADY_PROCESSED"),
+            Map.entry("HappyGalleryException", "BUSINESS_ERROR")
     );
 
     public static BatchResponse from(BatchResult result) {

--- a/app/src/main/java/com/personal/happygallery/app/web/admin/dto/BatchResponse.java
+++ b/app/src/main/java/com/personal/happygallery/app/web/admin/dto/BatchResponse.java
@@ -1,6 +1,7 @@
 package com.personal.happygallery.app.web.admin.dto;
 
 import com.personal.happygallery.app.batch.BatchResult;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public record BatchResponse(
@@ -9,7 +10,16 @@ public record BatchResponse(
         Map<String, Integer> failureReasons
 ) {
 
+    private static final Map<String, String> REASON_LABELS = Map.of(
+            "ObjectOptimisticLockingFailureException", "CONFLICT",
+            "OptimisticLockingFailureException", "CONFLICT",
+            "NotFoundException", "NOT_FOUND"
+    );
+
     public static BatchResponse from(BatchResult result) {
-        return new BatchResponse(result.successCount(), result.failureCount(), result.failureReasons());
+        Map<String, Integer> sanitized = new LinkedHashMap<>();
+        result.failureReasons().forEach((key, count) ->
+                sanitized.merge(REASON_LABELS.getOrDefault(key, "INTERNAL_ERROR"), count, Integer::sum));
+        return new BatchResponse(result.successCount(), result.failureCount(), sanitized);
     }
 }

--- a/app/src/main/java/com/personal/happygallery/app/web/admin/dto/FailedRefundResponse.java
+++ b/app/src/main/java/com/personal/happygallery/app/web/admin/dto/FailedRefundResponse.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 public record FailedRefundResponse(
         Long refundId,
         Long bookingId,
+        Long orderId,
         long amount,
         String failReason,
         LocalDateTime createdAt
@@ -14,7 +15,8 @@ public record FailedRefundResponse(
     public static FailedRefundResponse from(Refund refund) {
         return new FailedRefundResponse(
                 refund.getId(),
-                refund.getBooking().getId(),
+                refund.getBooking() != null ? refund.getBooking().getId() : null,
+                refund.getOrderId(),
                 refund.getAmount(),
                 refund.getFailReason() != null ? refund.getFailReason() : "",
                 refund.getCreatedAt()

--- a/app/src/main/java/com/personal/happygallery/config/SchedulingConfig.java
+++ b/app/src/main/java/com/personal/happygallery/config/SchedulingConfig.java
@@ -1,9 +1,20 @@
 package com.personal.happygallery.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @Configuration
 @EnableScheduling
 public class SchedulingConfig {
+
+    @Bean
+    public TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(4);
+        scheduler.setThreadNamePrefix("batch-");
+        return scheduler;
+    }
 }

--- a/app/src/test/java/com/personal/happygallery/app/booking/BookingCancelUseCaseIT.java
+++ b/app/src/test/java/com/personal/happygallery/app/booking/BookingCancelUseCaseIT.java
@@ -30,6 +30,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
@@ -166,6 +167,7 @@ class BookingCancelUseCaseIT {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].refundId").value(refund.getId()))
                 .andExpect(jsonPath("$[0].bookingId").value(booking.getId()))
+                .andExpect(jsonPath("$[0].orderId", nullValue()))
                 .andExpect(jsonPath("$[0].amount").value(5000))
                 .andExpect(jsonPath("$[0].failReason").value(""))
                 .andExpect(jsonPath("$[0].createdAt").isNotEmpty());

--- a/app/src/test/java/com/personal/happygallery/app/order/OrderApprovalUseCaseIT.java
+++ b/app/src/test/java/com/personal/happygallery/app/order/OrderApprovalUseCaseIT.java
@@ -34,7 +34,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
@@ -387,5 +390,32 @@ class OrderApprovalUseCaseIT {
 
         assertThat(updated1.getStatus()).isEqualTo(OrderStatus.AUTO_REFUNDED_TIMEOUT);
         assertThat(updated2.getStatus()).isEqualTo(OrderStatus.AUTO_REFUNDED_TIMEOUT);
+    }
+
+    // -----------------------------------------------------------------------
+    // Proof: 주문 환불 FAILED 건이 admin API에서 orderId와 함께 조회된다
+    // -----------------------------------------------------------------------
+
+    @DisplayName("주문 환불 실패 건이 admin 환불 실패 목록에서 orderId와 함께 조회된다")
+    @Test
+    void listFailedRefunds_orderRefund_returnsOrderIdWithoutNpe() throws Exception {
+        Product product = productRepository.save(new Product("주문환불실패 상품", ProductType.READY_STOCK, 90000L));
+        inventoryRepository.save(new Inventory(product, 1));
+
+        Order order = orderService.createPaidOrder(null,
+                java.util.List.of(new OrderService.OrderItemRequest(product.getId(), 1, 90000L)));
+
+        // 주문 환불 FAILED 직접 생성 (booking 없는 refund)
+        var refund = new com.personal.happygallery.domain.booking.Refund(order.getId(), 90000L);
+        refund.markFailed("PG 점검중");
+        refundRepository.save(refund);
+
+        mockMvc.perform(get("/admin/refunds/failed"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].refundId").value(refund.getId()))
+                .andExpect(jsonPath("$[0].bookingId", nullValue()))
+                .andExpect(jsonPath("$[0].orderId").value(order.getId()))
+                .andExpect(jsonPath("$[0].amount").value(90000))
+                .andExpect(jsonPath("$[0].failReason").value("PG 점검중"));
     }
 }

--- a/app/src/test/java/com/personal/happygallery/app/order/OrderProductionUseCaseIT.java
+++ b/app/src/test/java/com/personal/happygallery/app/order/OrderProductionUseCaseIT.java
@@ -184,4 +184,85 @@ class OrderProductionUseCaseIT {
         Order unchanged = orderRepository.findById(order.getId()).orElseThrow();
         assertThat(unchanged.getStatus()).isEqualTo(OrderStatus.IN_PRODUCTION);
     }
+
+    // -----------------------------------------------------------------------
+    // 제작 완료 → APPROVED_FULFILLMENT_PENDING → PICKUP_READY 전체 흐름
+    // -----------------------------------------------------------------------
+
+    @Test
+    void completeProduction_transitionsToApprovedFulfillmentPending() {
+        Product product = productRepository.save(
+                new Product("제작완료 상품", ProductType.MADE_TO_ORDER, 200000L));
+        inventoryRepository.save(new Inventory(product, 1));
+
+        Order order = orderService.createPaidOrder(null,
+                java.util.List.of(new OrderService.OrderItemRequest(product.getId(), 1, 200000L)));
+        orderApprovalService.approve(order.getId());
+
+        // IN_PRODUCTION → completeProduction → APPROVED_FULFILLMENT_PENDING
+        orderProductionService.completeProduction(order.getId(), 1L);
+
+        Order updated = orderRepository.findById(order.getId()).orElseThrow();
+        assertThat(updated.getStatus()).isEqualTo(OrderStatus.APPROVED_FULFILLMENT_PENDING);
+
+        Fulfillment fulfillment = fulfillmentRepository.findByOrderId(order.getId()).orElseThrow();
+        assertThat(fulfillment.getStatus()).isEqualTo(OrderStatus.APPROVED_FULFILLMENT_PENDING);
+
+        // 이력: APPROVE + PRODUCTION_COMPLETE
+        assertThat(orderApprovalHistoryRepository.findByOrderId(order.getId()))
+                .extracting("decision")
+                .containsExactly(OrderApprovalDecision.APPROVE, OrderApprovalDecision.PRODUCTION_COMPLETE);
+
+        // adminId 기록 확인
+        var histories = orderApprovalHistoryRepository.findByOrderId(order.getId());
+        assertThat(histories.get(1).getDecidedByAdminId()).isEqualTo(1L);
+    }
+
+    @Test
+    void completeProduction_fromDelayRequested_alsoWorks() {
+        Product product = productRepository.save(
+                new Product("지연 후 제작완료 상품", ProductType.MADE_TO_ORDER, 180000L));
+        inventoryRepository.save(new Inventory(product, 1));
+
+        Order order = orderService.createPaidOrder(null,
+                java.util.List.of(new OrderService.OrderItemRequest(product.getId(), 1, 180000L)));
+        orderApprovalService.approve(order.getId());
+        orderProductionService.requestDelay(order.getId());
+
+        // DELAY_REQUESTED → completeProduction → APPROVED_FULFILLMENT_PENDING
+        orderProductionService.completeProduction(order.getId(), null);
+
+        Order updated = orderRepository.findById(order.getId()).orElseThrow();
+        assertThat(updated.getStatus()).isEqualTo(OrderStatus.APPROVED_FULFILLMENT_PENDING);
+    }
+
+    @Test
+    void completeProduction_thenPickupReady_fullFlow() throws Exception {
+        Product product = productRepository.save(
+                new Product("제작→픽업 전체 흐름 상품", ProductType.MADE_TO_ORDER, 250000L));
+        inventoryRepository.save(new Inventory(product, 1));
+
+        Order order = orderService.createPaidOrder(null,
+                java.util.List.of(new OrderService.OrderItemRequest(product.getId(), 1, 250000L)));
+
+        // 승인 → IN_PRODUCTION
+        orderApprovalService.approve(order.getId());
+        assertThat(orderRepository.findById(order.getId()).orElseThrow().getStatus())
+                .isEqualTo(OrderStatus.IN_PRODUCTION);
+
+        // 제작 완료 → APPROVED_FULFILLMENT_PENDING
+        orderProductionService.completeProduction(order.getId(), 1L);
+        assertThat(orderRepository.findById(order.getId()).orElseThrow().getStatus())
+                .isEqualTo(OrderStatus.APPROVED_FULFILLMENT_PENDING);
+
+        // 픽업 준비 → PICKUP_READY (기존 흐름과 연결 확인)
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .post("/admin/orders/{id}/prepare-pickup", order.getId())
+                        .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                        .content("{\"pickupDeadlineAt\":\"2026-04-01T18:00:00\"}"))
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.status().isOk());
+
+        Order final_ = orderRepository.findById(order.getId()).orElseThrow();
+        assertThat(final_.getStatus()).isEqualTo(OrderStatus.PICKUP_READY);
+    }
 }

--- a/docs/PRD/0001_spec/spec.md
+++ b/docs/PRD/0001_spec/spec.md
@@ -171,7 +171,7 @@
     - `REJECTED_REFUNDED`
     - `AUTO_REFUNDED_TIMEOUT`
     - 픽업: `PICKUP_READY` → `PICKED_UP` / `PICKUP_EXPIRED_REFUNDED`
-    - 제작: `IN_PRODUCTION`(환불 불가 시작점) 등
+    - 제작: `IN_PRODUCTION` → (선택) `DELAY_REQUESTED` → `APPROVED_FULFILLMENT_PENDING`(제작 완료) → 픽업/배송 흐름 합류
 - 예약: `BOOKED` / `CANCELED` / `NO_SHOW` / `COMPLETED`
     - 결제/미수금은 별도 필드로 분리
 
@@ -207,7 +207,7 @@
 - `order_items`
     - id, order_id, product_id, qty, unit_price
 - `order_approvals`
-    - id, order_id, decided_by_admin_id, decision(APPROVE|REJECT|DELAY|AUTO_REFUND), reason, decided_at
+    - id, order_id, decided_by_admin_id, decision(APPROVE|REJECT|DELAY|AUTO_REFUND|PRODUCTION_COMPLETE), reason, decided_at
     - `AUTO_REFUND`는 배치 결정 이력이며 `decided_by_admin_id`는 null일 수 있음
 - `fulfillments`
     - id, order_id, type(SHIPPING|PICKUP), status, address/pickup_store, expected_ship_date, pickup_deadline_at, version
@@ -601,6 +601,30 @@ POST /admin/orders/expire-pickups
 정책:
 - `pickup_deadline_at < now` 인 `PICKUP_READY` 주문만 처리한다.
 - 성공 건은 `PICKUP_EXPIRED_REFUNDED`로 전이하고 환불/재고 복구를 수행한다.
+
+### 11-G.2 제작 완료 (§8.3)
+
+```
+POST /admin/orders/{id}/complete-production
+Header: X-Admin-Id: {adminId}  (선택)
+
+→ 200 OK
+{
+  "orderId": 5,
+  "status": "APPROVED_FULFILLMENT_PENDING",
+  "expectedShipDate": "2026-04-15"
+}
+```
+
+에러:
+- `404 NOT_FOUND` — orderId 미존재
+- `400 INVALID_INPUT` — IN_PRODUCTION 또는 DELAY_REQUESTED 상태가 아닌 주문
+
+정책:
+- `IN_PRODUCTION` 또는 `DELAY_REQUESTED` → `APPROVED_FULFILLMENT_PENDING`으로 전이한다.
+- Fulfillment 상태도 동기화한다.
+- 이력에 `PRODUCTION_COMPLETE` + adminId를 기록한다.
+- 이후 `prepare-pickup` 또는 배송 흐름으로 이어진다.
 
 ---
 

--- a/docs/PRD/0001_spec/spec.md
+++ b/docs/PRD/0001_spec/spec.md
@@ -212,7 +212,7 @@
 - `fulfillments`
     - id, order_id, type(SHIPPING|PICKUP), status, address/pickup_store, expected_ship_date, pickup_deadline_at, version
 - `refunds`
-    - id, order_id, amount, status(REQUESTED|SUCCEEDED|FAILED), pg_ref, fail_reason, created_at
+    - id, order_id nullable, booking_id nullable, amount, status(REQUESTED|SUCCEEDED|FAILED), pg_ref, fail_reason, created_at
 
 중요 인덱스:
 - `orders(status, approval_deadline_at)`
@@ -593,7 +593,7 @@ POST /admin/orders/expire-pickups
   "successCount": 2,
   "failureCount": 1,
   "failureReasons": {
-    "NotFoundException": 1
+    "NOT_FOUND": 1
   }
 }
 ```
@@ -601,6 +601,42 @@ POST /admin/orders/expire-pickups
 정책:
 - `pickup_deadline_at < now` 인 `PICKUP_READY` 주문만 처리한다.
 - 성공 건은 `PICKUP_EXPIRED_REFUNDED`로 전이하고 환불/재고 복구를 수행한다.
+
+---
+
+## 11-H. 환불 실패 관리 Admin API (§12 감사 로그)
+
+### 11-H.1 환불 실패 목록 조회
+
+```
+GET /admin/refunds/failed
+
+→ 200 OK
+[
+  {
+    "refundId": 42,
+    "bookingId": 15,       // 예약금 환불이면 bookingId, 주문 환불이면 null
+    "orderId": null,        // 주문 환불이면 orderId, 예약금 환불이면 null
+    "amount": 5000,
+    "failReason": "PG 타임아웃",
+    "createdAt": "2026-03-01T14:30:00"
+  }
+]
+```
+
+### 11-H.2 환불 재시도
+
+```
+POST /admin/refunds/{refundId}/retry
+
+→ 200 OK (본문 없음)
+```
+
+에러:
+- `404 NOT_FOUND` — refundId 미존재
+- `400 INVALID_INPUT` — FAILED 상태가 아닌 환불 재시도 시도
+
+정책: FAILED 상태 환불만 재시도 가능. 성공 시 SUCCEEDED, 재실패 시 FAILED 유지.
 
 ---
 

--- a/domain/src/main/java/com/personal/happygallery/domain/order/Fulfillment.java
+++ b/domain/src/main/java/com/personal/happygallery/domain/order/Fulfillment.java
@@ -82,8 +82,11 @@ public class Fulfillment {
         this.expectedShipDate = expectedShipDate;
     }
 
-    /** 주문 상태와 동기화한다. */
+    /** 주문 상태와 동기화한다. null이면 무시한다. */
     public void syncStatus(OrderStatus status) {
+        if (status == null) {
+            return;
+        }
         this.status = status;
     }
 

--- a/domain/src/main/java/com/personal/happygallery/domain/order/Order.java
+++ b/domain/src/main/java/com/personal/happygallery/domain/order/Order.java
@@ -114,6 +114,17 @@ public class Order {
     }
 
     /**
+     * 제작 완료 처리. {@link OrderStatus#IN_PRODUCTION} 또는 {@link OrderStatus#DELAY_REQUESTED}
+     * 상태에서만 호출 가능하며, {@link OrderStatus#APPROVED_FULFILLMENT_PENDING}으로 전이한다.
+     */
+    public void completeProduction() {
+        if (this.status != OrderStatus.IN_PRODUCTION && this.status != OrderStatus.DELAY_REQUESTED) {
+            throw new HappyGalleryException(ErrorCode.INVALID_INPUT);
+        }
+        this.status = OrderStatus.APPROVED_FULFILLMENT_PENDING;
+    }
+
+    /**
      * 24시간 초과 자동환불 처리.
      * 이미 환불된 주문에 대한 호출은 {@link com.personal.happygallery.common.error.AlreadyRefundedException}을 던진다.
      */

--- a/domain/src/main/java/com/personal/happygallery/domain/order/OrderApprovalDecision.java
+++ b/domain/src/main/java/com/personal/happygallery/domain/order/OrderApprovalDecision.java
@@ -4,5 +4,6 @@ public enum OrderApprovalDecision {
     APPROVE,
     REJECT,
     DELAY,
-    AUTO_REFUND
+    AUTO_REFUND,
+    PRODUCTION_COMPLETE
 }

--- a/infra/src/main/java/com/personal/happygallery/infra/booking/RefundRepository.java
+++ b/infra/src/main/java/com/personal/happygallery/infra/booking/RefundRepository.java
@@ -4,8 +4,10 @@ import com.personal.happygallery.domain.booking.Refund;
 import com.personal.happygallery.domain.order.RefundStatus;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface RefundRepository extends JpaRepository<Refund, Long> {
 
+    @Query("SELECT r FROM Refund r LEFT JOIN FETCH r.booking WHERE r.status = :status")
     List<Refund> findByStatus(RefundStatus status);
 }

--- a/infra/src/main/java/com/personal/happygallery/infra/booking/RefundRepository.java
+++ b/infra/src/main/java/com/personal/happygallery/infra/booking/RefundRepository.java
@@ -5,9 +5,10 @@ import com.personal.happygallery.domain.order.RefundStatus;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RefundRepository extends JpaRepository<Refund, Long> {
 
     @Query("SELECT r FROM Refund r LEFT JOIN FETCH r.booking WHERE r.status = :status")
-    List<Refund> findByStatus(RefundStatus status);
+    List<Refund> findByStatus(@Param("status") RefundStatus status);
 }


### PR DESCRIPTION
## 변경 사항
- 배치 안정성 보강: 알림 배치 건별 실패 격리, 스케줄러 스레드풀 설정, failureReasons 응답 정규화
- 환불 실패 관리 보강: orderId 포함 응답 확장, 실패 목록 조회 쿼리(fetch join + @Param) 수정
- 주문 제작 흐름 확장: complete-production 전이 추가 및 승인 이력(adminId/PRODUCTION_COMPLETE) 반영
- 관련 통합 테스트 및 PRD 명세 업데이트

## 테스트 방법
- `GRADLE_USER_HOME=/tmp/.gradle ./gradlew --no-daemon :app:test`
- `GRADLE_USER_HOME=/tmp/.gradle ./gradlew --no-daemon :app:test --tests com.personal.happygallery.app.booking.BookingCancelUseCaseIT --tests com.personal.happygallery.app.order.OrderApprovalUseCaseIT`

## 체크리스트
- [x] 테스트 추가됨
- [x] 문서 업데이트됨
- [x] Breaking change 없음