### PR TITLE
로컬 Docker 실행 구성을 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.gradle
+**/build
+frontend/node_modules
+frontend/dist
+.env
+*.md
+docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM eclipse-temurin:21-jdk AS build
+WORKDIR /app
+COPY gradlew settings.gradle build.gradle ./
+COPY gradle ./gradle
+COPY app ./app
+COPY common ./common
+COPY domain ./domain
+COPY infra ./infra
+RUN chmod +x gradlew && ./gradlew :app:bootJar --no-daemon -x test
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build /app/app/build/libs/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,6 +1,6 @@
 # HANDOFF.md
 > 다음 세션을 위한 인수인계 문서.
-> 작성 시점: 2026-03-08 (리팩토링 R1–R10 완료, frontend plan F8/F9 주문 화면 추가)
+> 작성 시점: 2026-03-08 (리팩토링 R1–R10 완료, 로컬 Docker 실행 추가)
 
 ---
 
@@ -31,6 +31,7 @@
   - F7 8회권 구매 화면 추가
   - F8 관리자 운영 확장 컴포넌트 추가
   - F9 사용자 주문 화면 컴포넌트 추가
+  - `docker-compose.yml`, `Dockerfile`, `.dockerignore`로 로컬 컨테이너 실행 경로 추가
 - 프론트 생성물(`node_modules`, `dist`, `*.tsbuildinfo`)은 `frontend/.gitignore` 기준으로 추적 제외
 - 최근 검증:
   - `./gradlew :app:policyTest` 통과

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,9 @@ services:
       - "3306:3306"
     environment:
       MYSQL_DATABASE: happygallery
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
-      MYSQL_USER: ${MYSQL_USER}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-rootpass}
+      MYSQL_USER: ${MYSQL_USER:-happygallery}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-password}
       TZ: UTC
     command:
       - --character-set-server=utf8mb4
@@ -24,6 +24,21 @@ services:
       timeout: 5s
       retries: 5
       start_period: 20s
+
+  app:
+    build: .
+    container_name: happygallery-app
+    ports:
+      - "8080:8080"
+    environment:
+      SPRING_PROFILES_ACTIVE: local
+      DB_URL: jdbc:mysql://mysql:3306/happygallery?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC&characterEncoding=UTF-8
+      DB_USERNAME: ${MYSQL_USER:-happygallery}
+      DB_PASSWORD: ${MYSQL_PASSWORD:-password}
+      ADMIN_API_KEY: ${ADMIN_API_KEY:-dev-admin-key}
+    depends_on:
+      mysql:
+        condition: service_healthy
 
 volumes:
   mysql_data:


### PR DESCRIPTION
## 변경 사항
- `docker-compose.yml`에 MySQL 기본 환경변수 fallback과 `app` 서비스를 추가했습니다.
- 멀티스테이지 `Dockerfile`을 추가해 `:app:bootJar` 산출물로 애플리케이션 이미지를 빌드할 수 있게 했습니다.
- `.dockerignore`를 추가해 Docker build context를 줄였습니다.
- `HANDOFF.md`에 로컬 Docker 실행 추가 상태를 반영했습니다.

## 테스트 방법
- `docker compose config`
- `./gradlew :app:bootJar -x test`

## 체크리스트
- [ ] 테스트 추가됨
- [x] 문서 업데이트됨
- [x] Breaking change 없음