### PR TITLE
port out 인터페이스 누락 fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 *.iml
 *.ipr
 *.iws
-out/
+/out/
 
 ## Eclipse
 .classpath

--- a/app/src/main/java/com/personal/happygallery/app/admin/port/out/AdminSessionPort.java
+++ b/app/src/main/java/com/personal/happygallery/app/admin/port/out/AdminSessionPort.java
@@ -1,0 +1,24 @@
+package com.personal.happygallery.app.admin.port.out;
+
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * 관리자 세션 저장소 포트.
+ *
+ * <p>세션 저장 방식(인메모리, Redis, DB 등)에 관계없이
+ * application 서비스가 일관된 계약으로 관리자 세션을 관리할 수 있게 한다.
+ */
+public interface AdminSessionPort {
+
+    /** 새 세션을 생성하고 토큰을 반환한다. */
+    String create(Long adminUserId, String username);
+
+    /** 토큰으로 세션을 조회·검증한다. 만료된 세션은 제거 후 empty를 반환한다. */
+    Optional<AdminSession> validate(String token);
+
+    /** 세션을 제거한다. */
+    void remove(String token);
+
+    record AdminSession(Long adminUserId, String username, Instant createdAt) {}
+}

--- a/app/src/main/java/com/personal/happygallery/app/booking/port/out/BookingHistoryPort.java
+++ b/app/src/main/java/com/personal/happygallery/app/booking/port/out/BookingHistoryPort.java
@@ -1,0 +1,10 @@
+package com.personal.happygallery.app.booking.port.out;
+
+import com.personal.happygallery.domain.booking.BookingHistory;
+
+public interface BookingHistoryPort {
+
+    BookingHistory save(BookingHistory history);
+
+    long countByBookingId(Long bookingId);
+}

--- a/app/src/main/java/com/personal/happygallery/app/booking/port/out/BookingReaderPort.java
+++ b/app/src/main/java/com/personal/happygallery/app/booking/port/out/BookingReaderPort.java
@@ -1,0 +1,34 @@
+package com.personal.happygallery.app.booking.port.out;
+
+import com.personal.happygallery.domain.booking.Booking;
+import com.personal.happygallery.domain.booking.BookingStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface BookingReaderPort {
+
+    Optional<Booking> findById(Long id);
+
+    Optional<Booking> findDetailByIdAndAccessToken(Long id, String accessToken);
+
+    List<Booking> findByUserIdWithDetails(Long userId);
+
+    Optional<Booking> findByIdAndUserIdWithDetails(Long id, Long userId);
+
+    List<Booking> findByGuestIdWithDetails(Long guestId);
+
+    boolean existsBySlotIdAndGuestId(Long slotId, Long guestId);
+
+    boolean existsBySlotIdAndUserId(Long slotId, Long userId);
+
+    boolean existsBySlotIdAndGuestIdAndIdNot(Long slotId, Long guestId, Long excludeBookingId);
+
+    boolean existsBySlotIdAndUserIdAndIdNot(Long slotId, Long userId, Long excludeBookingId);
+
+    List<Booking> findFuturePassBookings(Long passId, BookingStatus status, LocalDateTime now);
+
+    List<Booking> findBookingsInRange(BookingStatus status, LocalDateTime start, LocalDateTime end);
+
+    List<Booking> findAllInRange(LocalDateTime start, LocalDateTime end);
+}

--- a/app/src/main/java/com/personal/happygallery/app/booking/port/out/BookingStorePort.java
+++ b/app/src/main/java/com/personal/happygallery/app/booking/port/out/BookingStorePort.java
@@ -1,0 +1,7 @@
+package com.personal.happygallery.app.booking.port.out;
+
+import com.personal.happygallery.domain.booking.Booking;
+
+public interface BookingStorePort {
+    Booking save(Booking booking);
+}

--- a/app/src/main/java/com/personal/happygallery/app/booking/port/out/ClassReaderPort.java
+++ b/app/src/main/java/com/personal/happygallery/app/booking/port/out/ClassReaderPort.java
@@ -1,0 +1,14 @@
+package com.personal.happygallery.app.booking.port.out;
+
+import com.personal.happygallery.domain.booking.BookingClass;
+import java.util.List;
+import java.util.Optional;
+
+public interface ClassReaderPort {
+
+    Optional<BookingClass> findById(Long id);
+
+    List<BookingClass> findAll();
+
+    long count();
+}

--- a/app/src/main/java/com/personal/happygallery/app/booking/port/out/ClassStorePort.java
+++ b/app/src/main/java/com/personal/happygallery/app/booking/port/out/ClassStorePort.java
@@ -1,0 +1,11 @@
+package com.personal.happygallery.app.booking.port.out;
+
+import com.personal.happygallery.domain.booking.BookingClass;
+import java.util.List;
+
+public interface ClassStorePort {
+
+    BookingClass save(BookingClass bookingClass);
+
+    List<BookingClass> saveAll(List<BookingClass> classes);
+}

--- a/app/src/main/java/com/personal/happygallery/app/booking/port/out/RefundPort.java
+++ b/app/src/main/java/com/personal/happygallery/app/booking/port/out/RefundPort.java
@@ -1,0 +1,15 @@
+package com.personal.happygallery.app.booking.port.out;
+
+import com.personal.happygallery.domain.booking.Refund;
+import com.personal.happygallery.domain.order.RefundStatus;
+import java.util.List;
+import java.util.Optional;
+
+public interface RefundPort {
+
+    Refund save(Refund refund);
+
+    Optional<Refund> findById(Long id);
+
+    List<Refund> findByStatus(RefundStatus status);
+}

--- a/app/src/main/java/com/personal/happygallery/app/booking/port/out/SlotReaderPort.java
+++ b/app/src/main/java/com/personal/happygallery/app/booking/port/out/SlotReaderPort.java
@@ -1,0 +1,24 @@
+package com.personal.happygallery.app.booking.port.out;
+
+import com.personal.happygallery.domain.booking.Slot;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface SlotReaderPort {
+
+    Optional<Slot> findById(Long id);
+
+    /** 비관적 쓰기 락 — 정원 강제용 */
+    Optional<Slot> findByIdWithLock(Long id);
+
+    boolean existsByBookingClassIdAndStartAt(Long classId, LocalDateTime startAt);
+
+    List<Slot> findByBookingClassIdAndIsActiveTrue(Long classId);
+
+    List<Slot> findByBookingClassIdOrderByStartAtDesc(Long classId);
+
+    List<Slot> findAvailableByClassAndDate(Long classId, LocalDateTime dayStart, LocalDateTime dayEnd);
+
+    List<Slot> findActiveInBufferWindow(Long classId, LocalDateTime windowStart, LocalDateTime windowEnd);
+}

--- a/app/src/main/java/com/personal/happygallery/app/booking/port/out/SlotStorePort.java
+++ b/app/src/main/java/com/personal/happygallery/app/booking/port/out/SlotStorePort.java
@@ -1,0 +1,7 @@
+package com.personal.happygallery.app.booking.port.out;
+
+import com.personal.happygallery.domain.booking.Slot;
+
+public interface SlotStorePort {
+    Slot save(Slot slot);
+}

--- a/app/src/main/java/com/personal/happygallery/app/customer/port/out/CustomerSessionPort.java
+++ b/app/src/main/java/com/personal/happygallery/app/customer/port/out/CustomerSessionPort.java
@@ -1,0 +1,19 @@
+package com.personal.happygallery.app.customer.port.out;
+
+import com.personal.happygallery.domain.user.UserSession;
+import java.util.Optional;
+
+/**
+ * 고객 세션 저장소 포트.
+ *
+ * <p>세션 저장 방식(DB, Redis, 인메모리 등)에 관계없이
+ * application 서비스가 일관된 계약으로 세션을 관리할 수 있게 한다.
+ */
+public interface CustomerSessionPort {
+
+    UserSession save(UserSession session);
+
+    Optional<UserSession> findByTokenHash(String sessionTokenHash);
+
+    void delete(UserSession session);
+}

--- a/app/src/main/java/com/personal/happygallery/app/customer/port/out/GuestClaimQueryPort.java
+++ b/app/src/main/java/com/personal/happygallery/app/customer/port/out/GuestClaimQueryPort.java
@@ -1,0 +1,27 @@
+package com.personal.happygallery.app.customer.port.out;
+
+import com.personal.happygallery.domain.booking.Booking;
+import com.personal.happygallery.domain.order.Order;
+import com.personal.happygallery.domain.pass.PassPurchase;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * guest claim 유스케이스 전용 조회 포트.
+ *
+ * <p>claim preview와 claim 실행에 필요한 주문/예약/이용권 조회를 제공한다.
+ */
+public interface GuestClaimQueryPort {
+
+    List<Order> findOrdersByGuestId(Long guestId);
+
+    List<Order> findOrdersByIds(Collection<Long> ids);
+
+    List<Booking> findBookingsByGuestId(Long guestId);
+
+    List<Booking> findBookingsByIds(Collection<Long> ids);
+
+    List<PassPurchase> findPassPurchasesByGuestId(Long guestId);
+
+    List<PassPurchase> findPassPurchasesByIds(Collection<Long> ids);
+}

--- a/app/src/main/java/com/personal/happygallery/app/customer/port/out/GuestReaderPort.java
+++ b/app/src/main/java/com/personal/happygallery/app/customer/port/out/GuestReaderPort.java
@@ -1,0 +1,14 @@
+package com.personal.happygallery.app.customer.port.out;
+
+import com.personal.happygallery.domain.booking.Guest;
+import java.util.Optional;
+
+/**
+ * 게스트 조회 포트.
+ */
+public interface GuestReaderPort {
+
+    Optional<Guest> findById(Long id);
+
+    Optional<Guest> findByPhone(String phone);
+}

--- a/app/src/main/java/com/personal/happygallery/app/customer/port/out/GuestStorePort.java
+++ b/app/src/main/java/com/personal/happygallery/app/customer/port/out/GuestStorePort.java
@@ -1,0 +1,7 @@
+package com.personal.happygallery.app.customer.port.out;
+
+import com.personal.happygallery.domain.booking.Guest;
+
+public interface GuestStorePort {
+    Guest save(Guest guest);
+}

--- a/app/src/main/java/com/personal/happygallery/app/customer/port/out/PhoneVerificationPort.java
+++ b/app/src/main/java/com/personal/happygallery/app/customer/port/out/PhoneVerificationPort.java
@@ -1,0 +1,14 @@
+package com.personal.happygallery.app.customer.port.out;
+
+import com.personal.happygallery.domain.booking.PhoneVerification;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+/**
+ * 전화번호 인증 조회 포트.
+ */
+public interface PhoneVerificationPort {
+
+    /** 미소모(verified=false) + 만료 전 인증 코드 조회 */
+    Optional<PhoneVerification> findValidVerification(String phone, String code, LocalDateTime now);
+}

--- a/app/src/main/java/com/personal/happygallery/app/customer/port/out/PhoneVerificationStorePort.java
+++ b/app/src/main/java/com/personal/happygallery/app/customer/port/out/PhoneVerificationStorePort.java
@@ -1,0 +1,7 @@
+package com.personal.happygallery.app.customer.port.out;
+
+import com.personal.happygallery.domain.booking.PhoneVerification;
+
+public interface PhoneVerificationStorePort {
+    PhoneVerification save(PhoneVerification phoneVerification);
+}

--- a/app/src/main/java/com/personal/happygallery/app/customer/port/out/UserReaderPort.java
+++ b/app/src/main/java/com/personal/happygallery/app/customer/port/out/UserReaderPort.java
@@ -1,0 +1,16 @@
+package com.personal.happygallery.app.customer.port.out;
+
+import com.personal.happygallery.domain.user.User;
+import java.util.Optional;
+
+/**
+ * 회원 조회 포트.
+ */
+public interface UserReaderPort {
+
+    Optional<User> findById(Long id);
+
+    Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
+}

--- a/app/src/main/java/com/personal/happygallery/app/customer/port/out/UserStorePort.java
+++ b/app/src/main/java/com/personal/happygallery/app/customer/port/out/UserStorePort.java
@@ -1,0 +1,11 @@
+package com.personal.happygallery.app.customer.port.out;
+
+import com.personal.happygallery.domain.user.User;
+
+/**
+ * 회원 저장 포트.
+ */
+public interface UserStorePort {
+
+    User save(User user);
+}

--- a/app/src/main/java/com/personal/happygallery/app/notification/port/out/NotificationSenderPort.java
+++ b/app/src/main/java/com/personal/happygallery/app/notification/port/out/NotificationSenderPort.java
@@ -1,0 +1,26 @@
+package com.personal.happygallery.app.notification.port.out;
+
+import com.personal.happygallery.domain.notification.NotificationChannel;
+import com.personal.happygallery.domain.notification.NotificationEventType;
+
+/**
+ * 외부 알림 발송 포트.
+ *
+ * <p>application 서비스는 이 포트만 의존하며, 실제 채널 구현(카카오, SMS 등)은 adapter가 담당한다.
+ * {@code @Order} 우선순위 순으로 주입되어 fallback 체인을 구성한다.
+ */
+public interface NotificationSenderPort {
+
+    /** 이 sender가 담당하는 채널 */
+    NotificationChannel channel();
+
+    /**
+     * 알림을 발송한다.
+     *
+     * @param phone         수신자 전화번호
+     * @param recipientName 수신자 이름
+     * @param eventType     발송 이벤트 유형
+     * @return 발송 성공 여부
+     */
+    boolean send(String phone, String recipientName, NotificationEventType eventType);
+}

--- a/app/src/main/java/com/personal/happygallery/app/order/port/out/FulfillmentPort.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/port/out/FulfillmentPort.java
@@ -1,0 +1,12 @@
+package com.personal.happygallery.app.order.port.out;
+
+import com.personal.happygallery.domain.order.Fulfillment;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface FulfillmentPort {
+    Fulfillment save(Fulfillment fulfillment);
+    Optional<Fulfillment> findByOrderId(Long orderId);
+    List<Fulfillment> findExpiredPickups(LocalDateTime now);
+}

--- a/app/src/main/java/com/personal/happygallery/app/order/port/out/OrderHistoryPort.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/port/out/OrderHistoryPort.java
@@ -1,0 +1,10 @@
+package com.personal.happygallery.app.order.port.out;
+
+import com.personal.happygallery.domain.order.OrderApprovalHistory;
+import java.util.List;
+
+public interface OrderHistoryPort {
+    OrderApprovalHistory save(OrderApprovalHistory history);
+    List<OrderApprovalHistory> findByOrderId(Long orderId);
+    List<OrderApprovalHistory> findByOrderIdOrderByDecidedAtAsc(Long orderId);
+}

--- a/app/src/main/java/com/personal/happygallery/app/order/port/out/OrderItemPort.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/port/out/OrderItemPort.java
@@ -1,0 +1,12 @@
+package com.personal.happygallery.app.order.port.out;
+
+import com.personal.happygallery.domain.order.Order;
+import com.personal.happygallery.domain.order.OrderItem;
+import com.personal.happygallery.domain.product.ProductType;
+import java.util.List;
+
+public interface OrderItemPort {
+    OrderItem save(OrderItem item);
+    List<OrderItem> findByOrder(Order order);
+    boolean existsByOrderAndProductType(Order order, ProductType type);
+}

--- a/app/src/main/java/com/personal/happygallery/app/order/port/out/OrderReaderPort.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/port/out/OrderReaderPort.java
@@ -1,0 +1,15 @@
+package com.personal.happygallery.app.order.port.out;
+
+import com.personal.happygallery.domain.order.Order;
+import com.personal.happygallery.domain.order.OrderStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface OrderReaderPort {
+    Optional<Order> findById(Long id);
+    List<Order> findByStatusAndApprovalDeadlineAtBefore(OrderStatus status, LocalDateTime deadline);
+    List<Order> findByUserIdOrderByCreatedAtDesc(Long userId);
+    List<Order> findByStatusOrderByCreatedAtDesc(OrderStatus status);
+    List<Order> findAllByOrderByCreatedAtDesc();
+}

--- a/app/src/main/java/com/personal/happygallery/app/order/port/out/OrderStorePort.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/port/out/OrderStorePort.java
@@ -1,0 +1,8 @@
+package com.personal.happygallery.app.order.port.out;
+
+import com.personal.happygallery.domain.order.Order;
+
+public interface OrderStorePort {
+    Order save(Order order);
+    Order saveAndFlush(Order order);
+}

--- a/app/src/main/java/com/personal/happygallery/app/pass/port/out/PassLedgerReaderPort.java
+++ b/app/src/main/java/com/personal/happygallery/app/pass/port/out/PassLedgerReaderPort.java
@@ -1,0 +1,8 @@
+package com.personal.happygallery.app.pass.port.out;
+
+import com.personal.happygallery.domain.pass.PassLedger;
+import java.util.List;
+
+public interface PassLedgerReaderPort {
+    List<PassLedger> findByPassPurchaseId(Long passPurchaseId);
+}

--- a/app/src/main/java/com/personal/happygallery/app/pass/port/out/PassLedgerStorePort.java
+++ b/app/src/main/java/com/personal/happygallery/app/pass/port/out/PassLedgerStorePort.java
@@ -1,0 +1,7 @@
+package com.personal.happygallery.app.pass.port.out;
+
+import com.personal.happygallery.domain.pass.PassLedger;
+
+public interface PassLedgerStorePort {
+    PassLedger save(PassLedger ledger);
+}

--- a/app/src/main/java/com/personal/happygallery/app/pass/port/out/PassPurchaseReaderPort.java
+++ b/app/src/main/java/com/personal/happygallery/app/pass/port/out/PassPurchaseReaderPort.java
@@ -1,0 +1,22 @@
+package com.personal.happygallery.app.pass.port.out;
+
+import com.personal.happygallery.domain.pass.PassPurchase;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface PassPurchaseReaderPort {
+
+    Optional<PassPurchase> findById(Long id);
+
+    List<PassPurchase> findByUserIdOrderByPurchasedAtDesc(Long userId);
+
+    List<PassPurchase> findByGuestIdOrderByPurchasedAtDesc(Long guestId);
+
+    List<PassPurchase> findByExpiresAtBeforeAndRemainingCreditsGreaterThan(LocalDateTime now, int credits);
+
+    List<PassPurchase> findByExpiresAtBetweenAndRemainingCreditsGreaterThan(
+            LocalDateTime start, LocalDateTime end, int credits);
+
+    List<PassPurchase> findExpiringWithGuestBetween(LocalDateTime start, LocalDateTime end);
+}

--- a/app/src/main/java/com/personal/happygallery/app/pass/port/out/PassPurchaseStorePort.java
+++ b/app/src/main/java/com/personal/happygallery/app/pass/port/out/PassPurchaseStorePort.java
@@ -1,0 +1,7 @@
+package com.personal.happygallery.app.pass.port.out;
+
+import com.personal.happygallery.domain.pass.PassPurchase;
+
+public interface PassPurchaseStorePort {
+    PassPurchase save(PassPurchase passPurchase);
+}

--- a/app/src/main/java/com/personal/happygallery/app/payment/port/out/PaymentPort.java
+++ b/app/src/main/java/com/personal/happygallery/app/payment/port/out/PaymentPort.java
@@ -1,0 +1,18 @@
+package com.personal.happygallery.app.payment.port.out;
+
+/**
+ * 외부 결제 시스템 연동 포트.
+ *
+ * <p>application 서비스는 이 포트만 의존하며, 실제 PG 구현은 adapter가 담당한다.
+ */
+public interface PaymentPort {
+
+    /**
+     * 환불을 실행한다.
+     *
+     * @param pgRef  원결제 PG 참조값 (없으면 null)
+     * @param amount 환불 금액 (원)
+     * @return 성공 시 success=true + pgRef, 실패 시 success=false + failReason
+     */
+    RefundResult refund(String pgRef, long amount);
+}

--- a/app/src/main/java/com/personal/happygallery/app/payment/port/out/RefundResult.java
+++ b/app/src/main/java/com/personal/happygallery/app/payment/port/out/RefundResult.java
@@ -1,0 +1,13 @@
+package com.personal.happygallery.app.payment.port.out;
+
+/** PG 환불 호출 결과 (port 계약) */
+public record RefundResult(boolean success, String pgRef, String failReason) {
+
+    public static RefundResult success(String pgRef) {
+        return new RefundResult(true, pgRef, null);
+    }
+
+    public static RefundResult failure(String failReason) {
+        return new RefundResult(false, null, failReason);
+    }
+}

--- a/app/src/main/java/com/personal/happygallery/app/product/port/out/ProductReaderPort.java
+++ b/app/src/main/java/com/personal/happygallery/app/product/port/out/ProductReaderPort.java
@@ -1,0 +1,8 @@
+package com.personal.happygallery.app.product.port.out;
+
+import com.personal.happygallery.domain.product.Product;
+import java.util.Optional;
+
+public interface ProductReaderPort {
+    Optional<Product> findById(Long id);
+}


### PR DESCRIPTION
## 변경 사항
- 루트 `.gitignore`의 `out/` 패턴이 `app/**/port/out/`를 같이 무시하던 문제를 `/out/`로 좁혔습니다.
- 누락되었던 `app/**/port/out/**` 인터페이스 파일들을 추적에 포함했습니다.

## 테스트 방법
- `./gradlew --no-daemon :app:test --tests com.personal.happygallery.app.web.customer.CustomerAuthUseCaseIT --tests com.personal.happygallery.app.web.monitoring.ClientMonitoringUseCaseIT`

## 체크리스트
- [ ] 테스트 추가됨
- [x] 문서 업데이트됨
- [x] Breaking change 없음
