### PR TITLE
관리자 조회 MyBatis 전환과 ETag 캐시 설정 반영

### DIFF
--- a/app/src/main/java/com/personal/happygallery/app/batch/BatchExecutor.java
+++ b/app/src/main/java/com/personal/happygallery/app/batch/BatchExecutor.java
@@ -1,8 +1,11 @@
 package com.personal.happygallery.app.batch;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
@@ -72,9 +75,20 @@ public final class BatchExecutor {
                                                     Function<T, Boolean> processor,
                                                     String label) {
         BatchResult total = BatchResult.successOnly(0);
+        Set<Object> seenIds = new HashSet<>();
         List<T> page;
         while (!(page = pageFetcher.get()).isEmpty()) {
-            BatchResult pageResult = execute(page, idExtractor, processor, label);
+            List<T> fresh = new ArrayList<>();
+            for (T item : page) {
+                if (seenIds.add(idExtractor.apply(item))) {
+                    fresh.add(item);
+                }
+            }
+            if (fresh.isEmpty()) {
+                log.warn("{} 남은 항목이 모두 처리 완료 — 루프 종료", label);
+                break;
+            }
+            BatchResult pageResult = execute(fresh, idExtractor, processor, label);
             total = total.merge(pageResult);
             if (pageResult.successCount() == 0) {
                 log.warn("{} 페이지 진행 없음 — 루프 종료 (failureCount={})", label, pageResult.failureCount());

--- a/app/src/main/java/com/personal/happygallery/app/dashboard/DefaultDashboardQueryService.java
+++ b/app/src/main/java/com/personal/happygallery/app/dashboard/DefaultDashboardQueryService.java
@@ -1,0 +1,101 @@
+package com.personal.happygallery.app.dashboard;
+
+import com.personal.happygallery.app.dashboard.dto.DailyRevenue;
+import com.personal.happygallery.app.dashboard.dto.DashboardOverview;
+import com.personal.happygallery.app.dashboard.dto.Granularity;
+import com.personal.happygallery.app.dashboard.dto.PeriodSalesSummary;
+import com.personal.happygallery.app.dashboard.dto.RefundStats;
+import com.personal.happygallery.app.dashboard.dto.RevenueBreakdown;
+import com.personal.happygallery.app.dashboard.dto.SlotUtilization;
+import com.personal.happygallery.app.dashboard.dto.StatusCount;
+import com.personal.happygallery.app.dashboard.dto.TopProduct;
+import com.personal.happygallery.app.dashboard.dto.TopProductSort;
+import com.personal.happygallery.app.dashboard.port.in.DashboardQueryUseCase;
+import com.personal.happygallery.app.dashboard.port.out.BookingStatsQueryPort;
+import com.personal.happygallery.app.dashboard.port.out.SalesStatsQueryPort;
+import com.personal.happygallery.common.error.ErrorCode;
+import com.personal.happygallery.common.error.HappyGalleryException;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class DefaultDashboardQueryService implements DashboardQueryUseCase {
+
+    private static final int MAX_RANGE_DAYS = 365;
+    private static final int MAX_LIMIT = 100;
+
+    private final SalesStatsQueryPort salesStatsQueryPort;
+    private final BookingStatsQueryPort bookingStatsQueryPort;
+
+    public DefaultDashboardQueryService(SalesStatsQueryPort salesStatsQueryPort,
+                                        BookingStatsQueryPort bookingStatsQueryPort) {
+        this.salesStatsQueryPort = salesStatsQueryPort;
+        this.bookingStatsQueryPort = bookingStatsQueryPort;
+    }
+
+    @Override
+    public DashboardOverview getOverview(LocalDate from, LocalDate to) {
+        validateRange(from, to);
+        return salesStatsQueryPort.findOverview(from, to);
+    }
+
+    @Override
+    public List<PeriodSalesSummary> getSalesSummary(LocalDate from, LocalDate to, Granularity granularity) {
+        validateRange(from, to);
+        return salesStatsQueryPort.findSalesSummary(from, to, granularity);
+    }
+
+    @Override
+    public RevenueBreakdown getRevenueBreakdown(LocalDate from, LocalDate to) {
+        validateRange(from, to);
+        return salesStatsQueryPort.findRevenueBreakdown(from, to);
+    }
+
+    @Override
+    public List<StatusCount> getOrderStatusDistribution() {
+        return salesStatsQueryPort.findOrderStatusDistribution();
+    }
+
+    @Override
+    public RefundStats getRefundStats(LocalDate from, LocalDate to) {
+        validateRange(from, to);
+        return salesStatsQueryPort.findRefundStats(from, to);
+    }
+
+    @Override
+    public List<TopProduct> getTopProducts(LocalDate from, LocalDate to, int limit, TopProductSort sort) {
+        validateRange(from, to);
+        if (limit < 1 || limit > MAX_LIMIT) {
+            throw new HappyGalleryException(ErrorCode.INVALID_INPUT,
+                    "limit은 1~" + MAX_LIMIT + " 범위여야 합니다.");
+        }
+        return salesStatsQueryPort.findTopProducts(from, to, limit, sort);
+    }
+
+    @Override
+    public List<DailyRevenue> getDailyRevenueSeries(LocalDate from, LocalDate to) {
+        validateRange(from, to);
+        return salesStatsQueryPort.findDailyRevenueSeries(from, to);
+    }
+
+    @Override
+    public List<SlotUtilization> getSlotUtilization(LocalDate from, LocalDate to) {
+        validateRange(from, to);
+        return bookingStatsQueryPort.findSlotUtilization(from, to);
+    }
+
+    private void validateRange(LocalDate from, LocalDate to) {
+        if (from.isAfter(to)) {
+            throw new HappyGalleryException(ErrorCode.INVALID_INPUT,
+                    "from은 to보다 이전이어야 합니다: from=" + from + ", to=" + to);
+        }
+        if (ChronoUnit.DAYS.between(from, to) > MAX_RANGE_DAYS) {
+            throw new HappyGalleryException(ErrorCode.INVALID_INPUT,
+                    "조회 범위는 최대 " + MAX_RANGE_DAYS + "일입니다.");
+        }
+    }
+}

--- a/app/src/main/java/com/personal/happygallery/app/dashboard/dto/DailyRevenue.java
+++ b/app/src/main/java/com/personal/happygallery/app/dashboard/dto/DailyRevenue.java
@@ -1,0 +1,8 @@
+package com.personal.happygallery.app.dashboard.dto;
+
+import java.time.LocalDate;
+
+public record DailyRevenue(
+        LocalDate date,
+        long revenue
+) {}

--- a/app/src/main/java/com/personal/happygallery/app/dashboard/dto/DashboardOverview.java
+++ b/app/src/main/java/com/personal/happygallery/app/dashboard/dto/DashboardOverview.java
@@ -1,0 +1,10 @@
+package com.personal.happygallery.app.dashboard.dto;
+
+public record DashboardOverview(
+        long todayRevenue,
+        int todayOrderCount,
+        int pendingApprovalCount,
+        int todayBookingCount,
+        long monthRevenue,
+        int monthOrderCount
+) {}

--- a/app/src/main/java/com/personal/happygallery/app/dashboard/dto/Granularity.java
+++ b/app/src/main/java/com/personal/happygallery/app/dashboard/dto/Granularity.java
@@ -1,0 +1,5 @@
+package com.personal.happygallery.app.dashboard.dto;
+
+public enum Granularity {
+    DAILY, WEEKLY, MONTHLY
+}

--- a/app/src/main/java/com/personal/happygallery/app/dashboard/dto/PeriodSalesSummary.java
+++ b/app/src/main/java/com/personal/happygallery/app/dashboard/dto/PeriodSalesSummary.java
@@ -1,0 +1,8 @@
+package com.personal.happygallery.app.dashboard.dto;
+
+public record PeriodSalesSummary(
+        String periodLabel,
+        long totalRevenue,
+        int orderCount,
+        long avgOrderValue
+) {}

--- a/app/src/main/java/com/personal/happygallery/app/dashboard/dto/RefundStats.java
+++ b/app/src/main/java/com/personal/happygallery/app/dashboard/dto/RefundStats.java
@@ -1,0 +1,7 @@
+package com.personal.happygallery.app.dashboard.dto;
+
+public record RefundStats(
+        int totalRefundCount,
+        long totalRefundedAmount,
+        double refundRate
+) {}

--- a/app/src/main/java/com/personal/happygallery/app/dashboard/dto/RevenueBreakdown.java
+++ b/app/src/main/java/com/personal/happygallery/app/dashboard/dto/RevenueBreakdown.java
@@ -1,0 +1,9 @@
+package com.personal.happygallery.app.dashboard.dto;
+
+public record RevenueBreakdown(
+        long orderRevenue,
+        long bookingDepositRevenue,
+        long bookingBalanceRevenue,
+        long passPurchaseRevenue,
+        long totalRevenue
+) {}

--- a/app/src/main/java/com/personal/happygallery/app/dashboard/dto/SlotUtilization.java
+++ b/app/src/main/java/com/personal/happygallery/app/dashboard/dto/SlotUtilization.java
@@ -1,0 +1,11 @@
+package com.personal.happygallery.app.dashboard.dto;
+
+import java.time.LocalDate;
+
+public record SlotUtilization(
+        LocalDate date,
+        String className,
+        int totalCapacity,
+        int totalBooked,
+        double utilizationRate
+) {}

--- a/app/src/main/java/com/personal/happygallery/app/dashboard/dto/StatusCount.java
+++ b/app/src/main/java/com/personal/happygallery/app/dashboard/dto/StatusCount.java
@@ -1,0 +1,6 @@
+package com.personal.happygallery.app.dashboard.dto;
+
+public record StatusCount(
+        String status,
+        int count
+) {}

--- a/app/src/main/java/com/personal/happygallery/app/dashboard/dto/TopProduct.java
+++ b/app/src/main/java/com/personal/happygallery/app/dashboard/dto/TopProduct.java
@@ -1,0 +1,9 @@
+package com.personal.happygallery.app.dashboard.dto;
+
+public record TopProduct(
+        Long productId,
+        String productName,
+        String productType,
+        long totalRevenue,
+        int totalQuantity
+) {}

--- a/app/src/main/java/com/personal/happygallery/app/dashboard/dto/TopProductSort.java
+++ b/app/src/main/java/com/personal/happygallery/app/dashboard/dto/TopProductSort.java
@@ -1,0 +1,5 @@
+package com.personal.happygallery.app.dashboard.dto;
+
+public enum TopProductSort {
+    REVENUE, QUANTITY
+}

--- a/app/src/main/java/com/personal/happygallery/app/dashboard/port/in/DashboardQueryUseCase.java
+++ b/app/src/main/java/com/personal/happygallery/app/dashboard/port/in/DashboardQueryUseCase.java
@@ -1,0 +1,33 @@
+package com.personal.happygallery.app.dashboard.port.in;
+
+import com.personal.happygallery.app.dashboard.dto.DailyRevenue;
+import com.personal.happygallery.app.dashboard.dto.DashboardOverview;
+import com.personal.happygallery.app.dashboard.dto.Granularity;
+import com.personal.happygallery.app.dashboard.dto.PeriodSalesSummary;
+import com.personal.happygallery.app.dashboard.dto.RefundStats;
+import com.personal.happygallery.app.dashboard.dto.RevenueBreakdown;
+import com.personal.happygallery.app.dashboard.dto.SlotUtilization;
+import com.personal.happygallery.app.dashboard.dto.StatusCount;
+import com.personal.happygallery.app.dashboard.dto.TopProduct;
+import com.personal.happygallery.app.dashboard.dto.TopProductSort;
+import java.time.LocalDate;
+import java.util.List;
+
+public interface DashboardQueryUseCase {
+
+    DashboardOverview getOverview(LocalDate from, LocalDate to);
+
+    List<PeriodSalesSummary> getSalesSummary(LocalDate from, LocalDate to, Granularity granularity);
+
+    RevenueBreakdown getRevenueBreakdown(LocalDate from, LocalDate to);
+
+    List<StatusCount> getOrderStatusDistribution();
+
+    RefundStats getRefundStats(LocalDate from, LocalDate to);
+
+    List<TopProduct> getTopProducts(LocalDate from, LocalDate to, int limit, TopProductSort sort);
+
+    List<DailyRevenue> getDailyRevenueSeries(LocalDate from, LocalDate to);
+
+    List<SlotUtilization> getSlotUtilization(LocalDate from, LocalDate to);
+}

--- a/app/src/main/java/com/personal/happygallery/app/dashboard/port/out/BookingStatsQueryPort.java
+++ b/app/src/main/java/com/personal/happygallery/app/dashboard/port/out/BookingStatsQueryPort.java
@@ -1,0 +1,10 @@
+package com.personal.happygallery.app.dashboard.port.out;
+
+import com.personal.happygallery.app.dashboard.dto.SlotUtilization;
+import java.time.LocalDate;
+import java.util.List;
+
+public interface BookingStatsQueryPort {
+
+    List<SlotUtilization> findSlotUtilization(LocalDate from, LocalDate to);
+}

--- a/app/src/main/java/com/personal/happygallery/app/dashboard/port/out/SalesStatsQueryPort.java
+++ b/app/src/main/java/com/personal/happygallery/app/dashboard/port/out/SalesStatsQueryPort.java
@@ -1,0 +1,30 @@
+package com.personal.happygallery.app.dashboard.port.out;
+
+import com.personal.happygallery.app.dashboard.dto.DailyRevenue;
+import com.personal.happygallery.app.dashboard.dto.DashboardOverview;
+import com.personal.happygallery.app.dashboard.dto.Granularity;
+import com.personal.happygallery.app.dashboard.dto.PeriodSalesSummary;
+import com.personal.happygallery.app.dashboard.dto.RefundStats;
+import com.personal.happygallery.app.dashboard.dto.RevenueBreakdown;
+import com.personal.happygallery.app.dashboard.dto.StatusCount;
+import com.personal.happygallery.app.dashboard.dto.TopProduct;
+import com.personal.happygallery.app.dashboard.dto.TopProductSort;
+import java.time.LocalDate;
+import java.util.List;
+
+public interface SalesStatsQueryPort {
+
+    DashboardOverview findOverview(LocalDate from, LocalDate to);
+
+    List<PeriodSalesSummary> findSalesSummary(LocalDate from, LocalDate to, Granularity granularity);
+
+    RevenueBreakdown findRevenueBreakdown(LocalDate from, LocalDate to);
+
+    List<StatusCount> findOrderStatusDistribution();
+
+    RefundStats findRefundStats(LocalDate from, LocalDate to);
+
+    List<TopProduct> findTopProducts(LocalDate from, LocalDate to, int limit, TopProductSort sort);
+
+    List<DailyRevenue> findDailyRevenueSeries(LocalDate from, LocalDate to);
+}

--- a/app/src/main/java/com/personal/happygallery/app/order/DefaultOrderApprovalService.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/DefaultOrderApprovalService.java
@@ -1,32 +1,21 @@
 package com.personal.happygallery.app.order;
 
-import com.personal.happygallery.app.notification.NotificationService;
 import com.personal.happygallery.app.order.port.in.OrderApprovalUseCase;
-import com.personal.happygallery.app.payment.RefundExecutionService;
 import com.personal.happygallery.app.order.port.out.FulfillmentPort;
 import com.personal.happygallery.app.order.port.out.OrderHistoryPort;
 import com.personal.happygallery.app.order.port.out.OrderItemPort;
 import com.personal.happygallery.app.order.port.out.OrderReaderPort;
 import com.personal.happygallery.app.order.port.out.OrderStorePort;
-import com.personal.happygallery.app.product.InventoryService;
-import com.personal.happygallery.config.RetryConfig;
+import com.personal.happygallery.config.OptimisticLockRetryable;
 import com.personal.happygallery.common.error.NotFoundException;
-import com.personal.happygallery.domain.booking.Refund;
-import com.personal.happygallery.domain.notification.NotificationEventType;
 import com.personal.happygallery.domain.order.OrderApprovalDecision;
 import com.personal.happygallery.domain.order.OrderApprovalHistory;
 import com.personal.happygallery.domain.order.Fulfillment;
 import com.personal.happygallery.domain.order.FulfillmentType;
 import com.personal.happygallery.domain.order.Order;
-import com.personal.happygallery.domain.order.OrderItem;
-import com.personal.happygallery.domain.payment.RefundStatus;
 import com.personal.happygallery.domain.product.ProductType;
-import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -50,28 +39,22 @@ public class DefaultOrderApprovalService implements OrderApprovalUseCase {
     private final OrderReaderPort orderReader;
     private final OrderStorePort orderStore;
     private final OrderItemPort orderItemPort;
-    private final InventoryService inventoryService;
-    private final RefundExecutionService refundExecutionService;
     private final FulfillmentPort fulfillmentPort;
     private final OrderHistoryPort orderHistoryPort;
-    private final NotificationService notificationService;
+    private final OrderRefundSupport orderRefundSupport;
 
     public DefaultOrderApprovalService(OrderReaderPort orderReader,
                                 OrderStorePort orderStore,
                                 OrderItemPort orderItemPort,
-                                InventoryService inventoryService,
-                                RefundExecutionService refundExecutionService,
                                 FulfillmentPort fulfillmentPort,
                                 OrderHistoryPort orderHistoryPort,
-                                NotificationService notificationService) {
+                                OrderRefundSupport orderRefundSupport) {
         this.orderReader = orderReader;
         this.orderStore = orderStore;
         this.orderItemPort = orderItemPort;
-        this.inventoryService = inventoryService;
-        this.refundExecutionService = refundExecutionService;
         this.fulfillmentPort = fulfillmentPort;
         this.orderHistoryPort = orderHistoryPort;
-        this.notificationService = notificationService;
+        this.orderRefundSupport = orderRefundSupport;
     }
 
     /**
@@ -84,21 +67,12 @@ public class DefaultOrderApprovalService implements OrderApprovalUseCase {
      * @param orderId 주문 ID
      * @return 승인된 주문
      */
-    @Retryable(
-            retryFor = ObjectOptimisticLockingFailureException.class,
-            maxAttempts = 3,
-            backoff = @Backoff(delay = 50, multiplier = 2.0, random = true))
+    @OptimisticLockRetryable
     public Order approve(Long orderId) {
         return approve(orderId, null);
     }
 
-    @Retryable(
-            retryFor = ObjectOptimisticLockingFailureException.class,
-            maxAttempts = RetryConfig.OPTIMISTIC_LOCK_MAX_ATTEMPTS,
-            backoff = @Backoff(
-                    delay = RetryConfig.OPTIMISTIC_LOCK_INITIAL_DELAY_MILLIS,
-                    multiplier = RetryConfig.OPTIMISTIC_LOCK_BACKOFF_MULTIPLIER,
-                    random = true))
+    @OptimisticLockRetryable
     public Order approve(Long orderId, Long adminId) {
         Order order = orderReader.findById(orderId)
                 .orElseThrow(() -> new NotFoundException("주문"));
@@ -133,51 +107,23 @@ public class DefaultOrderApprovalService implements OrderApprovalUseCase {
      * @param orderId 주문 ID
      * @return 거절된 주문
      */
-    @Retryable(
-            retryFor = ObjectOptimisticLockingFailureException.class,
-            maxAttempts = 3,
-            backoff = @Backoff(delay = 50, multiplier = 2.0, random = true))
+    @OptimisticLockRetryable
     public Order reject(Long orderId) {
         return reject(orderId, null);
     }
 
-    @Retryable(
-            retryFor = ObjectOptimisticLockingFailureException.class,
-            maxAttempts = RetryConfig.OPTIMISTIC_LOCK_MAX_ATTEMPTS,
-            backoff = @Backoff(
-                    delay = RetryConfig.OPTIMISTIC_LOCK_INITIAL_DELAY_MILLIS,
-                    multiplier = RetryConfig.OPTIMISTIC_LOCK_BACKOFF_MULTIPLIER,
-                    random = true))
+    @OptimisticLockRetryable
     public Order reject(Long orderId, Long adminId) {
         Order order = orderReader.findById(orderId)
                 .orElseThrow(() -> new NotFoundException("주문"));
         order.reject();
 
-        restoreInventory(order);
-        boolean refundSucceeded = processRefund(order);
+        orderRefundSupport.refundOrder(order);
         orderHistoryPort.save(
                 new OrderApprovalHistory(order.getId(), OrderApprovalDecision.REJECT, adminId, null));
-        notifyRefundedGuest(order, refundSucceeded);
         log.info("order rejected [orderId={} adminId={}]", orderId, adminId);
 
         return orderStore.save(order);
     }
 
-    void restoreInventory(Order order) {
-        List<OrderItem> items = orderItemPort.findByOrder(order);
-        for (OrderItem item : items) {
-            inventoryService.restore(item.getProductId(), item.getQty());
-        }
-    }
-
-    boolean processRefund(Order order) {
-        Refund refund = refundExecutionService.processOrderRefund(order.getId(), order.getTotalAmount());
-        return refund.getStatus() == RefundStatus.SUCCEEDED;
-    }
-
-    void notifyRefundedGuest(Order order, boolean refundSucceeded) {
-        if (refundSucceeded) {
-            notificationService.notifyByGuestId(order.getGuestId(), NotificationEventType.ORDER_REFUNDED);
-        }
-    }
 }

--- a/app/src/main/java/com/personal/happygallery/app/order/DefaultOrderPickupService.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/DefaultOrderPickupService.java
@@ -4,16 +4,13 @@ import com.personal.happygallery.app.order.port.in.OrderPickupUseCase;
 import com.personal.happygallery.app.order.port.out.FulfillmentPort;
 import com.personal.happygallery.app.order.port.out.OrderReaderPort;
 import com.personal.happygallery.app.order.port.out.OrderStorePort;
-import com.personal.happygallery.config.RetryConfig;
+import com.personal.happygallery.config.OptimisticLockRetryable;
 import com.personal.happygallery.common.error.NotFoundException;
 import com.personal.happygallery.domain.order.Fulfillment;
 import com.personal.happygallery.domain.order.Order;
 import com.personal.happygallery.domain.order.OrderStatus;
 import java.time.LocalDateTime;
 import org.springframework.stereotype.Service;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -48,13 +45,7 @@ public class DefaultOrderPickupService implements OrderPickupUseCase {
      * @param pickupDeadlineAt 픽업 마감 시각
      * @return 픽업 결과 (주문 ID, 상태, 마감 시각)
      */
-    @Retryable(
-            retryFor = ObjectOptimisticLockingFailureException.class,
-            maxAttempts = RetryConfig.OPTIMISTIC_LOCK_MAX_ATTEMPTS,
-            backoff = @Backoff(
-                    delay = RetryConfig.OPTIMISTIC_LOCK_INITIAL_DELAY_MILLIS,
-                    multiplier = RetryConfig.OPTIMISTIC_LOCK_BACKOFF_MULTIPLIER,
-                    random = true))
+    @OptimisticLockRetryable
     public PickupResult markPickupReady(Long orderId, LocalDateTime pickupDeadlineAt) {
         Order order = orderReader.findById(orderId)
                 .orElseThrow(() -> new NotFoundException("주문"));
@@ -78,13 +69,7 @@ public class DefaultOrderPickupService implements OrderPickupUseCase {
      * @param orderId 주문 ID
      * @return 픽업 결과 (주문 ID, 상태, 마감 시각)
      */
-    @Retryable(
-            retryFor = ObjectOptimisticLockingFailureException.class,
-            maxAttempts = RetryConfig.OPTIMISTIC_LOCK_MAX_ATTEMPTS,
-            backoff = @Backoff(
-                    delay = RetryConfig.OPTIMISTIC_LOCK_INITIAL_DELAY_MILLIS,
-                    multiplier = RetryConfig.OPTIMISTIC_LOCK_BACKOFF_MULTIPLIER,
-                    random = true))
+    @OptimisticLockRetryable
     public PickupResult confirmPickup(Long orderId) {
         Order order = orderReader.findById(orderId)
                 .orElseThrow(() -> new NotFoundException("주문"));

--- a/app/src/main/java/com/personal/happygallery/app/order/DefaultOrderProductionService.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/DefaultOrderProductionService.java
@@ -5,7 +5,7 @@ import com.personal.happygallery.app.order.port.out.FulfillmentPort;
 import com.personal.happygallery.app.order.port.out.OrderHistoryPort;
 import com.personal.happygallery.app.order.port.out.OrderReaderPort;
 import com.personal.happygallery.app.order.port.out.OrderStorePort;
-import com.personal.happygallery.config.RetryConfig;
+import com.personal.happygallery.config.OptimisticLockRetryable;
 import com.personal.happygallery.common.error.NotFoundException;
 import com.personal.happygallery.domain.order.OrderApprovalDecision;
 import com.personal.happygallery.domain.order.OrderApprovalHistory;
@@ -14,9 +14,6 @@ import com.personal.happygallery.domain.order.Order;
 import com.personal.happygallery.domain.order.OrderStatus;
 import java.time.LocalDate;
 import org.springframework.stereotype.Service;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -56,13 +53,7 @@ public class DefaultOrderProductionService implements OrderProductionUseCase {
      * @param expectedShipDate 예상 출고일
      * @return 주문 상태 + 갱신된 출고일
      */
-    @Retryable(
-            retryFor = ObjectOptimisticLockingFailureException.class,
-            maxAttempts = RetryConfig.OPTIMISTIC_LOCK_MAX_ATTEMPTS,
-            backoff = @Backoff(
-                    delay = RetryConfig.OPTIMISTIC_LOCK_INITIAL_DELAY_MILLIS,
-                    multiplier = RetryConfig.OPTIMISTIC_LOCK_BACKOFF_MULTIPLIER,
-                    random = true))
+    @OptimisticLockRetryable
     public ProductionResult setExpectedShipDate(Long orderId, LocalDate expectedShipDate) {
         Order order = orderReader.findById(orderId)
                 .orElseThrow(() -> new NotFoundException("주문"));
@@ -84,13 +75,7 @@ public class DefaultOrderProductionService implements OrderProductionUseCase {
      * @param orderId 주문 ID
      * @return 전이된 주문 상태 + 출고일
      */
-    @Retryable(
-            retryFor = ObjectOptimisticLockingFailureException.class,
-            maxAttempts = RetryConfig.OPTIMISTIC_LOCK_MAX_ATTEMPTS,
-            backoff = @Backoff(
-                    delay = RetryConfig.OPTIMISTIC_LOCK_INITIAL_DELAY_MILLIS,
-                    multiplier = RetryConfig.OPTIMISTIC_LOCK_BACKOFF_MULTIPLIER,
-                    random = true))
+    @OptimisticLockRetryable
     public ProductionResult requestDelay(Long orderId) {
         Order order = orderReader.findById(orderId)
                 .orElseThrow(() -> new NotFoundException("주문"));
@@ -108,13 +93,7 @@ public class DefaultOrderProductionService implements OrderProductionUseCase {
      * 지연 요청 상태에서 제작을 재개한다.
      * {@link OrderStatus#DELAY_REQUESTED} → {@link OrderStatus#IN_PRODUCTION}.
      */
-    @Retryable(
-            retryFor = ObjectOptimisticLockingFailureException.class,
-            maxAttempts = RetryConfig.OPTIMISTIC_LOCK_MAX_ATTEMPTS,
-            backoff = @Backoff(
-                    delay = RetryConfig.OPTIMISTIC_LOCK_INITIAL_DELAY_MILLIS,
-                    multiplier = RetryConfig.OPTIMISTIC_LOCK_BACKOFF_MULTIPLIER,
-                    random = true))
+    @OptimisticLockRetryable
     public ProductionResult resumeProduction(Long orderId, Long adminId) {
         Order order = orderReader.findById(orderId)
                 .orElseThrow(() -> new NotFoundException("주문"));
@@ -134,13 +113,7 @@ public class DefaultOrderProductionService implements OrderProductionUseCase {
      * {@link OrderStatus#APPROVED_FULFILLMENT_PENDING}으로 전이한다.
      * 이후 픽업 준비({@code markPickupReady}) 또는 배송 흐름으로 이어진다.
      */
-    @Retryable(
-            retryFor = ObjectOptimisticLockingFailureException.class,
-            maxAttempts = RetryConfig.OPTIMISTIC_LOCK_MAX_ATTEMPTS,
-            backoff = @Backoff(
-                    delay = RetryConfig.OPTIMISTIC_LOCK_INITIAL_DELAY_MILLIS,
-                    multiplier = RetryConfig.OPTIMISTIC_LOCK_BACKOFF_MULTIPLIER,
-                    random = true))
+    @OptimisticLockRetryable
     public ProductionResult completeProduction(Long orderId, Long adminId) {
         Order order = orderReader.findById(orderId)
                 .orElseThrow(() -> new NotFoundException("주문"));

--- a/app/src/main/java/com/personal/happygallery/app/order/DefaultOrderShippingService.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/DefaultOrderShippingService.java
@@ -5,7 +5,7 @@ import com.personal.happygallery.app.order.port.out.FulfillmentPort;
 import com.personal.happygallery.app.order.port.out.OrderHistoryPort;
 import com.personal.happygallery.app.order.port.out.OrderReaderPort;
 import com.personal.happygallery.app.order.port.out.OrderStorePort;
-import com.personal.happygallery.config.RetryConfig;
+import com.personal.happygallery.config.OptimisticLockRetryable;
 import com.personal.happygallery.common.error.NotFoundException;
 import com.personal.happygallery.domain.order.Fulfillment;
 import com.personal.happygallery.domain.order.FulfillmentType;
@@ -14,9 +14,6 @@ import com.personal.happygallery.domain.order.OrderApprovalDecision;
 import com.personal.happygallery.domain.order.OrderApprovalHistory;
 import com.personal.happygallery.domain.order.OrderStatus;
 import java.time.LocalDate;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -50,13 +47,7 @@ public class DefaultOrderShippingService implements OrderShippingUseCase {
      * 배송 준비 시작. APPROVED_FULFILLMENT_PENDING → SHIPPING_PREPARING.
      * Fulfillment가 SHIPPING 타입이어야 한다 (없으면 새로 생성).
      */
-    @Retryable(
-            retryFor = ObjectOptimisticLockingFailureException.class,
-            maxAttempts = RetryConfig.OPTIMISTIC_LOCK_MAX_ATTEMPTS,
-            backoff = @Backoff(
-                    delay = RetryConfig.OPTIMISTIC_LOCK_INITIAL_DELAY_MILLIS,
-                    multiplier = RetryConfig.OPTIMISTIC_LOCK_BACKOFF_MULTIPLIER,
-                    random = true))
+    @OptimisticLockRetryable
     public ShippingResult prepareShipping(Long orderId, Long adminId) {
         Order order = orderReader.findById(orderId)
                 .orElseThrow(() -> new NotFoundException("주문"));
@@ -76,13 +67,7 @@ public class DefaultOrderShippingService implements OrderShippingUseCase {
     /**
      * 배송 출발. SHIPPING_PREPARING → SHIPPED.
      */
-    @Retryable(
-            retryFor = ObjectOptimisticLockingFailureException.class,
-            maxAttempts = RetryConfig.OPTIMISTIC_LOCK_MAX_ATTEMPTS,
-            backoff = @Backoff(
-                    delay = RetryConfig.OPTIMISTIC_LOCK_INITIAL_DELAY_MILLIS,
-                    multiplier = RetryConfig.OPTIMISTIC_LOCK_BACKOFF_MULTIPLIER,
-                    random = true))
+    @OptimisticLockRetryable
     public ShippingResult markShipped(Long orderId, Long adminId) {
         Order order = orderReader.findById(orderId)
                 .orElseThrow(() -> new NotFoundException("주문"));
@@ -100,13 +85,7 @@ public class DefaultOrderShippingService implements OrderShippingUseCase {
     /**
      * 배송 완료. SHIPPED → DELIVERED.
      */
-    @Retryable(
-            retryFor = ObjectOptimisticLockingFailureException.class,
-            maxAttempts = RetryConfig.OPTIMISTIC_LOCK_MAX_ATTEMPTS,
-            backoff = @Backoff(
-                    delay = RetryConfig.OPTIMISTIC_LOCK_INITIAL_DELAY_MILLIS,
-                    multiplier = RetryConfig.OPTIMISTIC_LOCK_BACKOFF_MULTIPLIER,
-                    random = true))
+    @OptimisticLockRetryable
     public ShippingResult markDelivered(Long orderId, Long adminId) {
         Order order = orderReader.findById(orderId)
                 .orElseThrow(() -> new NotFoundException("주문"));

--- a/app/src/main/java/com/personal/happygallery/app/order/OrderAutoRefundProcessor.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/OrderAutoRefundProcessor.java
@@ -3,15 +3,12 @@ package com.personal.happygallery.app.order;
 import com.personal.happygallery.app.order.port.out.OrderHistoryPort;
 import com.personal.happygallery.app.order.port.out.OrderReaderPort;
 import com.personal.happygallery.app.order.port.out.OrderStorePort;
-import com.personal.happygallery.config.RetryConfig;
+import com.personal.happygallery.config.OptimisticLockRetryable;
 import com.personal.happygallery.common.error.NotFoundException;
 import com.personal.happygallery.domain.order.Order;
 import com.personal.happygallery.domain.order.OrderApprovalDecision;
 import com.personal.happygallery.domain.order.OrderApprovalHistory;
 import java.time.LocalDateTime;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,27 +17,21 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrderAutoRefundProcessor {
     private final OrderReaderPort orderReader;
     private final OrderStorePort orderStore;
-    private final DefaultOrderApprovalService orderApprovalService;
+    private final OrderRefundSupport orderRefundSupport;
     private final OrderHistoryPort orderHistoryPort;
 
     public OrderAutoRefundProcessor(OrderReaderPort orderReader,
                                     OrderStorePort orderStore,
-                                    DefaultOrderApprovalService orderApprovalService,
+                                    OrderRefundSupport orderRefundSupport,
                                     OrderHistoryPort orderHistoryPort) {
         this.orderReader = orderReader;
         this.orderStore = orderStore;
-        this.orderApprovalService = orderApprovalService;
+        this.orderRefundSupport = orderRefundSupport;
         this.orderHistoryPort = orderHistoryPort;
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    @Retryable(
-            retryFor = ObjectOptimisticLockingFailureException.class,
-            maxAttempts = RetryConfig.OPTIMISTIC_LOCK_MAX_ATTEMPTS,
-            backoff = @Backoff(
-                    delay = RetryConfig.OPTIMISTIC_LOCK_INITIAL_DELAY_MILLIS,
-                    multiplier = RetryConfig.OPTIMISTIC_LOCK_BACKOFF_MULTIPLIER,
-                    random = true))
+    @OptimisticLockRetryable
     public boolean process(Long orderId, LocalDateTime now) {
         Order order = orderReader.findById(orderId)
                 .orElseThrow(() -> new NotFoundException("주문"));
@@ -48,14 +39,11 @@ public class OrderAutoRefundProcessor {
             return false;
         }
 
-        orderApprovalService.restoreInventory(order);
-        boolean refundSucceeded = orderApprovalService.processRefund(order);
+        orderRefundSupport.refundOrder(order);
         order.markAutoRefunded();
         orderHistoryPort.save(
                 new OrderApprovalHistory(order.getId(), OrderApprovalDecision.AUTO_REFUND));
         orderStore.saveAndFlush(order);
-
-        orderApprovalService.notifyRefundedGuest(order, refundSucceeded);
         return true;
     }
 }

--- a/app/src/main/java/com/personal/happygallery/app/order/OrderRefundSupport.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/OrderRefundSupport.java
@@ -1,0 +1,55 @@
+package com.personal.happygallery.app.order;
+
+import com.personal.happygallery.app.notification.NotificationService;
+import com.personal.happygallery.app.order.port.out.OrderItemPort;
+import com.personal.happygallery.app.payment.RefundExecutionService;
+import com.personal.happygallery.app.product.InventoryService;
+import com.personal.happygallery.domain.booking.Refund;
+import com.personal.happygallery.domain.notification.NotificationEventType;
+import com.personal.happygallery.domain.order.Order;
+import com.personal.happygallery.domain.order.OrderItem;
+import com.personal.happygallery.domain.payment.RefundStatus;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/**
+ * 주문 환불 공통 보조 로직.
+ *
+ * <p>재고 복구 → PG 환불 → 환불 알림 순서를 단일 지점에서 강제하여
+ * 주문 거절·자동환불·픽업 만료에서 동일한 보상 흐름을 보장한다.
+ */
+@Service
+class OrderRefundSupport {
+
+    private final OrderItemPort orderItemPort;
+    private final InventoryService inventoryService;
+    private final RefundExecutionService refundExecutionService;
+    private final NotificationService notificationService;
+
+    OrderRefundSupport(OrderItemPort orderItemPort,
+                       InventoryService inventoryService,
+                       RefundExecutionService refundExecutionService,
+                       NotificationService notificationService) {
+        this.orderItemPort = orderItemPort;
+        this.inventoryService = inventoryService;
+        this.refundExecutionService = refundExecutionService;
+        this.notificationService = notificationService;
+    }
+
+    /**
+     * 재고 복구 → PG 환불 → 환불 알림을 순서대로 수행한다.
+     *
+     * <p>환불 성공 시에만 게스트에게 알림을 발송한다.
+     */
+    void refundOrder(Order order) {
+        List<OrderItem> items = orderItemPort.findByOrder(order);
+        for (OrderItem item : items) {
+            inventoryService.restore(item.getProductId(), item.getQty());
+        }
+
+        Refund refund = refundExecutionService.processOrderRefund(order.getId(), order.getTotalAmount());
+        if (refund.getStatus() == RefundStatus.SUCCEEDED) {
+            notificationService.notifyByGuestId(order.getGuestId(), NotificationEventType.ORDER_REFUNDED);
+        }
+    }
+}

--- a/app/src/main/java/com/personal/happygallery/app/order/PickupExpireProcessor.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/PickupExpireProcessor.java
@@ -3,15 +3,12 @@ package com.personal.happygallery.app.order;
 import com.personal.happygallery.app.order.port.out.FulfillmentPort;
 import com.personal.happygallery.app.order.port.out.OrderReaderPort;
 import com.personal.happygallery.app.order.port.out.OrderStorePort;
-import com.personal.happygallery.config.RetryConfig;
+import com.personal.happygallery.config.OptimisticLockRetryable;
 import com.personal.happygallery.common.error.NotFoundException;
 import com.personal.happygallery.domain.order.Fulfillment;
 import com.personal.happygallery.domain.order.Order;
 import com.personal.happygallery.domain.order.OrderStatus;
 import java.time.LocalDateTime;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,26 +18,20 @@ public class PickupExpireProcessor {
     private final FulfillmentPort fulfillmentPort;
     private final OrderReaderPort orderReader;
     private final OrderStorePort orderStore;
-    private final DefaultOrderApprovalService orderApprovalService;
+    private final OrderRefundSupport orderRefundSupport;
 
     public PickupExpireProcessor(FulfillmentPort fulfillmentPort,
                                  OrderReaderPort orderReader,
                                  OrderStorePort orderStore,
-                                 DefaultOrderApprovalService orderApprovalService) {
+                                 OrderRefundSupport orderRefundSupport) {
         this.fulfillmentPort = fulfillmentPort;
         this.orderReader = orderReader;
         this.orderStore = orderStore;
-        this.orderApprovalService = orderApprovalService;
+        this.orderRefundSupport = orderRefundSupport;
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    @Retryable(
-            retryFor = ObjectOptimisticLockingFailureException.class,
-            maxAttempts = RetryConfig.OPTIMISTIC_LOCK_MAX_ATTEMPTS,
-            backoff = @Backoff(
-                    delay = RetryConfig.OPTIMISTIC_LOCK_INITIAL_DELAY_MILLIS,
-                    multiplier = RetryConfig.OPTIMISTIC_LOCK_BACKOFF_MULTIPLIER,
-                    random = true))
+    @OptimisticLockRetryable
     public boolean process(Long orderId, LocalDateTime now) {
         Order order = orderReader.findById(orderId)
                 .orElseThrow(() -> new NotFoundException("주문"));
@@ -54,12 +45,9 @@ public class PickupExpireProcessor {
             return false;
         }
 
-        orderApprovalService.restoreInventory(order);
-        boolean refundSucceeded = orderApprovalService.processRefund(order);
+        orderRefundSupport.refundOrder(order);
         order.markPickupExpired();
         orderStore.save(order);
-
-        orderApprovalService.notifyRefundedGuest(order, refundSucceeded);
         return true;
     }
 }

--- a/app/src/main/java/com/personal/happygallery/app/pass/DefaultPassRefundService.java
+++ b/app/src/main/java/com/personal/happygallery/app/pass/DefaultPassRefundService.java
@@ -82,20 +82,7 @@ public class DefaultPassRefundService implements PassRefundUseCase {
         List<Booking> futureBookings = bookingReader.findFuturePassBookings(
                 passId, BookingStatus.BOOKED, LocalDateTime.now(clock));
 
-        for (Booking booking : futureBookings) {
-            var slot = slotReader.findByIdWithLock(booking.getSlot().getId())
-                    .orElseThrow(() -> new NotFoundException("슬롯"));
-            slot.decrementBookedCount();
-            slotStore.save(slot);
-
-            bookingHistoryPort.save(
-                    new BookingHistory(booking, BookingHistoryAction.CANCELED,
-                            slot, null, "ADMIN", null));
-
-            booking.cancel();
-            bookingStore.save(booking);
-            log.info("Pass환불 연동 취소 [passId={}, bookingId={}]", passId, booking.getId());
-        }
+        futureBookings.forEach(booking -> cancelLinkedBooking(booking, passId));
 
         // 2. REFUND ledger 기록 (잔여 크레딧 전체)
         int refundCredits = pass.getRemainingCredits();
@@ -115,4 +102,18 @@ public class DefaultPassRefundService implements PassRefundUseCase {
         return new PassRefundResult(futureBookings.size(), refundCredits, refundAmount);
     }
 
+    private void cancelLinkedBooking(Booking booking, Long passId) {
+        var slot = slotReader.findByIdWithLock(booking.getSlot().getId())
+                .orElseThrow(() -> new NotFoundException("슬롯"));
+        slot.decrementBookedCount();
+        slotStore.save(slot);
+
+        bookingHistoryPort.save(
+                new BookingHistory(booking, BookingHistoryAction.CANCELED,
+                        slot, null, "ADMIN", null));
+
+        booking.cancel();
+        bookingStore.save(booking);
+        log.info("Pass환불 연동 취소 [passId={}, bookingId={}]", passId, booking.getId());
+    }
 }

--- a/app/src/main/java/com/personal/happygallery/app/search/DefaultAdminBookingSearchService.java
+++ b/app/src/main/java/com/personal/happygallery/app/search/DefaultAdminBookingSearchService.java
@@ -1,0 +1,33 @@
+package com.personal.happygallery.app.search;
+
+import com.personal.happygallery.app.search.dto.AdminBookingSearchRow;
+import com.personal.happygallery.app.search.port.in.AdminBookingSearchUseCase;
+import com.personal.happygallery.app.search.port.out.AdminBookingSearchPort;
+import com.personal.happygallery.app.web.OffsetPage;
+import com.personal.happygallery.domain.booking.BookingStatus;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+class DefaultAdminBookingSearchService implements AdminBookingSearchUseCase {
+
+    private final AdminBookingSearchPort searchPort;
+
+    DefaultAdminBookingSearchService(AdminBookingSearchPort searchPort) {
+        this.searchPort = searchPort;
+    }
+
+    @Override
+    public OffsetPage<AdminBookingSearchRow> search(BookingStatus status, LocalDate dateFrom, LocalDate dateTo,
+                                                     String keyword, int page, int size) {
+        long totalCount = searchPort.count(status, dateFrom, dateTo, keyword);
+        if (totalCount == 0) {
+            return OffsetPage.of(List.of(), page, size, 0);
+        }
+        List<AdminBookingSearchRow> rows = searchPort.search(status, dateFrom, dateTo, keyword, page * size, size);
+        return OffsetPage.of(rows, page, size, totalCount);
+    }
+}

--- a/app/src/main/java/com/personal/happygallery/app/search/DefaultAdminOrderSearchService.java
+++ b/app/src/main/java/com/personal/happygallery/app/search/DefaultAdminOrderSearchService.java
@@ -1,0 +1,33 @@
+package com.personal.happygallery.app.search;
+
+import com.personal.happygallery.app.search.dto.AdminOrderSearchRow;
+import com.personal.happygallery.app.search.port.in.AdminOrderSearchUseCase;
+import com.personal.happygallery.app.search.port.out.AdminOrderSearchPort;
+import com.personal.happygallery.app.web.OffsetPage;
+import com.personal.happygallery.domain.order.OrderStatus;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+class DefaultAdminOrderSearchService implements AdminOrderSearchUseCase {
+
+    private final AdminOrderSearchPort searchPort;
+
+    DefaultAdminOrderSearchService(AdminOrderSearchPort searchPort) {
+        this.searchPort = searchPort;
+    }
+
+    @Override
+    public OffsetPage<AdminOrderSearchRow> search(OrderStatus status, LocalDate dateFrom, LocalDate dateTo,
+                                                   String keyword, int page, int size) {
+        long totalCount = searchPort.count(status, dateFrom, dateTo, keyword);
+        if (totalCount == 0) {
+            return OffsetPage.of(List.of(), page, size, 0);
+        }
+        List<AdminOrderSearchRow> rows = searchPort.search(status, dateFrom, dateTo, keyword, page * size, size);
+        return OffsetPage.of(rows, page, size, totalCount);
+    }
+}

--- a/app/src/main/java/com/personal/happygallery/app/search/dto/AdminBookingSearchRow.java
+++ b/app/src/main/java/com/personal/happygallery/app/search/dto/AdminBookingSearchRow.java
@@ -1,0 +1,20 @@
+package com.personal.happygallery.app.search.dto;
+
+import java.time.LocalDateTime;
+
+public record AdminBookingSearchRow(
+        Long bookingId,
+        String bookingNumber,
+        String bookerType,
+        String bookerName,
+        String bookerPhone,
+        String className,
+        LocalDateTime startAt,
+        LocalDateTime endAt,
+        String status,
+        long depositAmount,
+        long balanceAmount,
+        boolean passBooking,
+        LocalDateTime createdAt
+) {
+}

--- a/app/src/main/java/com/personal/happygallery/app/search/dto/AdminOrderSearchRow.java
+++ b/app/src/main/java/com/personal/happygallery/app/search/dto/AdminOrderSearchRow.java
@@ -1,0 +1,16 @@
+package com.personal.happygallery.app.search.dto;
+
+import java.time.LocalDateTime;
+
+public record AdminOrderSearchRow(
+        Long orderId,
+        String orderNumber,
+        String status,
+        long totalAmount,
+        String buyerName,
+        String buyerPhone,
+        LocalDateTime paidAt,
+        LocalDateTime approvalDeadlineAt,
+        LocalDateTime createdAt
+) {
+}

--- a/app/src/main/java/com/personal/happygallery/app/search/port/in/AdminBookingSearchUseCase.java
+++ b/app/src/main/java/com/personal/happygallery/app/search/port/in/AdminBookingSearchUseCase.java
@@ -1,0 +1,12 @@
+package com.personal.happygallery.app.search.port.in;
+
+import com.personal.happygallery.app.search.dto.AdminBookingSearchRow;
+import com.personal.happygallery.app.web.OffsetPage;
+import com.personal.happygallery.domain.booking.BookingStatus;
+import java.time.LocalDate;
+
+public interface AdminBookingSearchUseCase {
+
+    OffsetPage<AdminBookingSearchRow> search(BookingStatus status, LocalDate dateFrom, LocalDate dateTo,
+                                              String keyword, int page, int size);
+}

--- a/app/src/main/java/com/personal/happygallery/app/search/port/in/AdminOrderSearchUseCase.java
+++ b/app/src/main/java/com/personal/happygallery/app/search/port/in/AdminOrderSearchUseCase.java
@@ -1,0 +1,12 @@
+package com.personal.happygallery.app.search.port.in;
+
+import com.personal.happygallery.app.search.dto.AdminOrderSearchRow;
+import com.personal.happygallery.app.web.OffsetPage;
+import com.personal.happygallery.domain.order.OrderStatus;
+import java.time.LocalDate;
+
+public interface AdminOrderSearchUseCase {
+
+    OffsetPage<AdminOrderSearchRow> search(OrderStatus status, LocalDate dateFrom, LocalDate dateTo,
+                                            String keyword, int page, int size);
+}

--- a/app/src/main/java/com/personal/happygallery/app/search/port/out/AdminBookingSearchPort.java
+++ b/app/src/main/java/com/personal/happygallery/app/search/port/out/AdminBookingSearchPort.java
@@ -1,0 +1,14 @@
+package com.personal.happygallery.app.search.port.out;
+
+import com.personal.happygallery.app.search.dto.AdminBookingSearchRow;
+import com.personal.happygallery.domain.booking.BookingStatus;
+import java.time.LocalDate;
+import java.util.List;
+
+public interface AdminBookingSearchPort {
+
+    List<AdminBookingSearchRow> search(BookingStatus status, LocalDate dateFrom, LocalDate dateTo,
+                                        String keyword, int offset, int size);
+
+    long count(BookingStatus status, LocalDate dateFrom, LocalDate dateTo, String keyword);
+}

--- a/app/src/main/java/com/personal/happygallery/app/search/port/out/AdminOrderSearchPort.java
+++ b/app/src/main/java/com/personal/happygallery/app/search/port/out/AdminOrderSearchPort.java
@@ -1,0 +1,14 @@
+package com.personal.happygallery.app.search.port.out;
+
+import com.personal.happygallery.app.search.dto.AdminOrderSearchRow;
+import com.personal.happygallery.domain.order.OrderStatus;
+import java.time.LocalDate;
+import java.util.List;
+
+public interface AdminOrderSearchPort {
+
+    List<AdminOrderSearchRow> search(OrderStatus status, LocalDate dateFrom, LocalDate dateTo,
+                                      String keyword, int offset, int size);
+
+    long count(OrderStatus status, LocalDate dateFrom, LocalDate dateTo, String keyword);
+}

--- a/app/src/main/java/com/personal/happygallery/app/web/OffsetPage.java
+++ b/app/src/main/java/com/personal/happygallery/app/web/OffsetPage.java
@@ -1,0 +1,26 @@
+package com.personal.happygallery.app.web;
+
+import java.util.List;
+
+/**
+ * OFFSET 기반 페이지 응답.
+ *
+ * @param content    현재 페이지의 항목 목록
+ * @param page       현재 페이지 번호 (0-based)
+ * @param size       페이지 크기
+ * @param totalCount 전체 항목 수
+ * @param totalPages 전체 페이지 수
+ */
+public record OffsetPage<T>(
+        List<T> content,
+        int page,
+        int size,
+        long totalCount,
+        int totalPages
+) {
+
+    public static <T> OffsetPage<T> of(List<T> content, int page, int size, long totalCount) {
+        int totalPages = (int) Math.ceil((double) totalCount / size);
+        return new OffsetPage<>(content, page, size, totalCount, totalPages);
+    }
+}

--- a/app/src/main/java/com/personal/happygallery/app/web/admin/AdminBookingController.java
+++ b/app/src/main/java/com/personal/happygallery/app/web/admin/AdminBookingController.java
@@ -2,6 +2,9 @@ package com.personal.happygallery.app.web.admin;
 
 import com.personal.happygallery.app.booking.port.in.AdminBookingQueryUseCase;
 import com.personal.happygallery.app.pass.port.in.PassNoShowUseCase;
+import com.personal.happygallery.app.search.dto.AdminBookingSearchRow;
+import com.personal.happygallery.app.search.port.in.AdminBookingSearchUseCase;
+import com.personal.happygallery.app.web.OffsetPage;
 import com.personal.happygallery.app.web.admin.dto.AdminBookingResponse;
 import com.personal.happygallery.app.web.admin.dto.BookingNoShowResponse;
 import com.personal.happygallery.domain.booking.Booking;
@@ -21,11 +24,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminBookingController {
 
     private final AdminBookingQueryUseCase adminBookingQueryUseCase;
+    private final AdminBookingSearchUseCase adminBookingSearchUseCase;
     private final PassNoShowUseCase passNoShowUseCase;
 
     public AdminBookingController(AdminBookingQueryUseCase adminBookingQueryUseCase,
+                                  AdminBookingSearchUseCase adminBookingSearchUseCase,
                                   PassNoShowUseCase passNoShowUseCase) {
         this.adminBookingQueryUseCase = adminBookingQueryUseCase;
+        this.adminBookingSearchUseCase = adminBookingSearchUseCase;
         this.passNoShowUseCase = passNoShowUseCase;
     }
 
@@ -35,6 +41,18 @@ public class AdminBookingController {
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
             @RequestParam(required = false) BookingStatus status) {
         return adminBookingQueryUseCase.listBookings(date, status);
+    }
+
+    /** GET /admin/bookings/search — 상태·날짜·키워드 기반 예약 검색 (OFFSET + 지연 조인) */
+    @GetMapping("/search")
+    public OffsetPage<AdminBookingSearchRow> searchBookings(
+            @RequestParam(required = false) BookingStatus status,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dateFrom,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dateTo,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        return adminBookingSearchUseCase.search(status, dateFrom, dateTo, keyword, page, size);
     }
 
     /** 결석 처리 — 8회권 크레딧 소멸 유지, 상태 NO_SHOW 전이 */

--- a/app/src/main/java/com/personal/happygallery/app/web/admin/AdminDashboardController.java
+++ b/app/src/main/java/com/personal/happygallery/app/web/admin/AdminDashboardController.java
@@ -1,0 +1,88 @@
+package com.personal.happygallery.app.web.admin;
+
+import com.personal.happygallery.app.dashboard.dto.DailyRevenue;
+import com.personal.happygallery.app.dashboard.dto.DashboardOverview;
+import com.personal.happygallery.app.dashboard.dto.Granularity;
+import com.personal.happygallery.app.dashboard.dto.PeriodSalesSummary;
+import com.personal.happygallery.app.dashboard.dto.RefundStats;
+import com.personal.happygallery.app.dashboard.dto.RevenueBreakdown;
+import com.personal.happygallery.app.dashboard.dto.SlotUtilization;
+import com.personal.happygallery.app.dashboard.dto.StatusCount;
+import com.personal.happygallery.app.dashboard.dto.TopProduct;
+import com.personal.happygallery.app.dashboard.dto.TopProductSort;
+import com.personal.happygallery.app.dashboard.port.in.DashboardQueryUseCase;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping({"/api/v1/admin/dashboard", "/admin/dashboard"})
+public class AdminDashboardController {
+
+    private final DashboardQueryUseCase dashboardQueryUseCase;
+
+    public AdminDashboardController(DashboardQueryUseCase dashboardQueryUseCase) {
+        this.dashboardQueryUseCase = dashboardQueryUseCase;
+    }
+
+    @GetMapping("/overview")
+    public DashboardOverview overview(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
+        return dashboardQueryUseCase.getOverview(from, to);
+    }
+
+    @GetMapping("/sales-summary")
+    public List<PeriodSalesSummary> salesSummary(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+            @RequestParam(defaultValue = "DAILY") Granularity granularity) {
+        return dashboardQueryUseCase.getSalesSummary(from, to, granularity);
+    }
+
+    @GetMapping("/revenue-breakdown")
+    public RevenueBreakdown revenueBreakdown(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
+        return dashboardQueryUseCase.getRevenueBreakdown(from, to);
+    }
+
+    @GetMapping("/order-status")
+    public List<StatusCount> orderStatusDistribution() {
+        return dashboardQueryUseCase.getOrderStatusDistribution();
+    }
+
+    @GetMapping("/refunds")
+    public RefundStats refundStats(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
+        return dashboardQueryUseCase.getRefundStats(from, to);
+    }
+
+    @GetMapping("/top-products")
+    public List<TopProduct> topProducts(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+            @RequestParam(defaultValue = "10") int limit,
+            @RequestParam(defaultValue = "REVENUE") TopProductSort sort) {
+        return dashboardQueryUseCase.getTopProducts(from, to, limit, sort);
+    }
+
+    @GetMapping("/daily-revenue")
+    public List<DailyRevenue> dailyRevenue(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
+        return dashboardQueryUseCase.getDailyRevenueSeries(from, to);
+    }
+
+    @GetMapping("/slot-utilization")
+    public List<SlotUtilization> slotUtilization(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
+        return dashboardQueryUseCase.getSlotUtilization(from, to);
+    }
+}

--- a/app/src/main/java/com/personal/happygallery/app/web/admin/AdminOrderController.java
+++ b/app/src/main/java/com/personal/happygallery/app/web/admin/AdminOrderController.java
@@ -7,7 +7,10 @@ import com.personal.happygallery.app.order.port.in.OrderPickupUseCase;
 import com.personal.happygallery.app.order.port.in.OrderProductionUseCase;
 import com.personal.happygallery.app.order.port.in.OrderShippingUseCase;
 import com.personal.happygallery.app.order.port.in.PickupExpireBatchUseCase;
+import com.personal.happygallery.app.search.dto.AdminOrderSearchRow;
+import com.personal.happygallery.app.search.port.in.AdminOrderSearchUseCase;
 import com.personal.happygallery.app.web.CursorPage;
+import com.personal.happygallery.app.web.OffsetPage;
 import com.personal.happygallery.app.web.admin.dto.AdminOrderResponse;
 import com.personal.happygallery.app.web.admin.dto.BatchResponse;
 import com.personal.happygallery.app.web.admin.dto.MarkPickupReadyRequest;
@@ -19,7 +22,9 @@ import com.personal.happygallery.app.web.admin.dto.ShippingResponse;
 import com.personal.happygallery.app.web.AdminAuthFilter;
 import com.personal.happygallery.domain.order.OrderStatus;
 import jakarta.servlet.http.HttpServletRequest;
+import java.time.LocalDate;
 import java.util.List;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -36,6 +41,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminOrderController {
 
     private final AdminOrderQueryUseCase adminOrderQueryUseCase;
+    private final AdminOrderSearchUseCase adminOrderSearchUseCase;
     private final OrderApprovalUseCase orderApprovalUseCase;
     private final OrderProductionUseCase orderProductionUseCase;
     private final OrderPickupUseCase orderPickupUseCase;
@@ -43,12 +49,14 @@ public class AdminOrderController {
     private final PickupExpireBatchUseCase pickupExpireBatchUseCase;
 
     public AdminOrderController(AdminOrderQueryUseCase adminOrderQueryUseCase,
+                                AdminOrderSearchUseCase adminOrderSearchUseCase,
                                 OrderApprovalUseCase orderApprovalUseCase,
                                 OrderProductionUseCase orderProductionUseCase,
                                 OrderPickupUseCase orderPickupUseCase,
                                 OrderShippingUseCase orderShippingUseCase,
                                 PickupExpireBatchUseCase pickupExpireBatchUseCase) {
         this.adminOrderQueryUseCase = adminOrderQueryUseCase;
+        this.adminOrderSearchUseCase = adminOrderSearchUseCase;
         this.orderApprovalUseCase = orderApprovalUseCase;
         this.orderProductionUseCase = orderProductionUseCase;
         this.orderPickupUseCase = orderPickupUseCase;
@@ -63,6 +71,18 @@ public class AdminOrderController {
             @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "20") int size) {
         return adminOrderQueryUseCase.listOrders(status, cursor, size);
+    }
+
+    /** GET /admin/orders/search — 상태·날짜·키워드 기반 주문 검색 (OFFSET + 지연 조인) */
+    @GetMapping("/search")
+    public OffsetPage<AdminOrderSearchRow> searchOrders(
+            @RequestParam(required = false) OrderStatus status,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dateFrom,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dateTo,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        return adminOrderSearchUseCase.search(status, dateFrom, dateTo, keyword, page, size);
     }
 
     /** POST /admin/orders/{id}/approve — 주문 승인 (MADE_TO_ORDER는 IN_PRODUCTION으로 전이) */

--- a/app/src/main/java/com/personal/happygallery/config/EtagFilterConfig.java
+++ b/app/src/main/java/com/personal/happygallery/config/EtagFilterConfig.java
@@ -1,0 +1,21 @@
+package com.personal.happygallery.config;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.filter.ShallowEtagHeaderFilter;
+
+@Configuration
+public class EtagFilterConfig {
+
+    @Bean
+    FilterRegistrationBean<ShallowEtagHeaderFilter> shallowEtagHeaderFilter() {
+        var registration = new FilterRegistrationBean<>(new ShallowEtagHeaderFilter());
+        registration.addUrlPatterns(
+                "/api/v1/products/*", "/api/v1/classes/*", "/api/v1/notices/*",
+                "/products/*", "/classes/*", "/notices/*"
+        );
+        registration.setOrder(0);
+        return registration;
+    }
+}

--- a/app/src/main/java/com/personal/happygallery/config/OptimisticLockRetryable.java
+++ b/app/src/main/java/com/personal/happygallery/config/OptimisticLockRetryable.java
@@ -1,0 +1,27 @@
+package com.personal.happygallery.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+
+/**
+ * 낙관적 락 충돌 시 재시도하는 메타 어노테이션.
+ *
+ * <p>{@link RetryConfig}의 상수를 단일 지점에서 참조하여
+ * 서비스 메서드마다 {@code @Retryable} 보일러플레이트를 반복하지 않도록 한다.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Retryable(
+        retryFor = ObjectOptimisticLockingFailureException.class,
+        maxAttempts = RetryConfig.OPTIMISTIC_LOCK_MAX_ATTEMPTS,
+        backoff = @Backoff(
+                delay = RetryConfig.OPTIMISTIC_LOCK_INITIAL_DELAY_MILLIS,
+                multiplier = RetryConfig.OPTIMISTIC_LOCK_BACKOFF_MULTIPLIER,
+                random = true))
+public @interface OptimisticLockRetryable {
+}

--- a/app/src/main/java/com/personal/happygallery/config/properties/AdminProperties.java
+++ b/app/src/main/java/com/personal/happygallery/config/properties/AdminProperties.java
@@ -1,10 +1,13 @@
 package com.personal.happygallery.config.properties;
 
+import jakarta.validation.constraints.NotNull;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.DefaultValue;
+import org.springframework.validation.annotation.Validated;
 
+@Validated
 @ConfigurationProperties(prefix = "app.admin")
 public record AdminProperties(
-        @DefaultValue("") String apiKey,
+        @NotNull @DefaultValue("") String apiKey,
         @DefaultValue("false") boolean enableApiKeyAuth
 ) {}

--- a/app/src/main/java/com/personal/happygallery/config/properties/FieldEncryptionProperties.java
+++ b/app/src/main/java/com/personal/happygallery/config/properties/FieldEncryptionProperties.java
@@ -1,9 +1,12 @@
 package com.personal.happygallery.config.properties;
 
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
+@Validated
 @ConfigurationProperties(prefix = "app.field-encryption")
 public record FieldEncryptionProperties(
-        String encryptKey,
-        String hmacKey
+        @NotBlank String encryptKey,
+        @NotBlank String hmacKey
 ) {}

--- a/app/src/main/resources/db/migration/V25__add_dashboard_stats_indexes.sql
+++ b/app/src/main/resources/db/migration/V25__add_dashboard_stats_indexes.sql
@@ -1,0 +1,15 @@
+-- ==========================================================
+-- V25: 대시보드 통계 집계 쿼리 최적화 인덱스
+-- ==========================================================
+
+-- 주문 매출 집계: paid_at 범위 스캔 (sargable WHERE paid_at >= ? AND paid_at < ?)
+CREATE INDEX idx_orders_paid_at ON orders (paid_at);
+
+-- 예약 입금 집계: deposit_paid_at 범위 스캔
+CREATE INDEX idx_bookings_deposit_paid_at ON bookings (deposit_paid_at);
+
+-- 이용권 매출 집계: purchased_at 범위 스캔
+CREATE INDEX idx_pass_purchases_purchased_at ON pass_purchases (purchased_at);
+
+-- 인기 상품 집계: order_id로 JOIN 후 product_id 집계 + unit_price·qty 커버링
+CREATE INDEX idx_order_items_order_product ON order_items (order_id, product_id, unit_price, qty);

--- a/app/src/test/resources/application-test.yml
+++ b/app/src/test/resources/application-test.yml
@@ -12,6 +12,14 @@ app:
   field-encryption:
     encrypt-key: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
     hmac-key: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+  external:
+    kakao:
+      api-key: "test-kakao-api-key"
+      sender-key: "test-kakao-sender-key"
+    sms:
+      api-key: "test-sms-api-key"
+      api-secret: "test-sms-api-secret"
+      sender-number: "01000000000"
 
 logging:
   level:

--- a/docs/Idea/0032_HTTP_캐싱_ETag_고도화
+++ b/docs/Idea/0032_HTTP_캐싱_ETag_고도화
@@ -1,0 +1,42 @@
+# 0032 — HTTP 캐싱 ETag 고도화
+
+## 현재 상태 (Phase 1 — 완료)
+
+`ShallowEtagHeaderFilter`를 products, classes, notices GET 엔드포인트에 적용.
+
+- 응답 body의 MD5 해시를 `ETag` 헤더로 내려줌
+- 클라이언트가 `If-None-Match`를 보내면 body 비교 후 `304 Not Modified` 반환
+- **한계**: DB 쿼리와 직렬화는 매번 실행됨 — 네트워크 트래픽만 절감
+
+## Phase 2 — Caffeine 로컬 캐시 + Cache-Control (미적용)
+
+트래픽 증가 시 아래 방식으로 고도화한다.
+
+### 적용 대상
+
+| API | Cache-Control | 캐시 TTL | 무효화 시점 |
+|-----|---------------|---------|------------|
+| `GET /products` | `max-age=60` | 60초 | 상품 등록/수정/상태 변경 |
+| `GET /products/{id}` | `max-age=60` | 60초 | 해당 상품 수정 |
+| `GET /classes` | `max-age=300` | 5분 | 클래스 추가/변경 |
+| `GET /notices` | `max-age=120` | 2분 | 공지 생성/수정 |
+
+### 구현 방향
+
+1. **Caffeine 캐시** 도입 (`spring-boot-starter-cache` + `caffeine`)
+   - 서비스 계층에서 `@Cacheable` / `@CacheEvict` 적용
+   - DB 쿼리 자체를 스킵하여 응답 지연과 DB 부하 동시 절감
+
+2. **`Cache-Control` 헤더** 추가
+   - 브라우저가 TTL 동안 서버 요청 자체를 하지 않음
+   - TTL 만료 후에는 `ETag`로 304 판단
+
+3. **캐시 무효화**
+   - 관리자 API에서 상품/클래스/공지 CUD 시 `@CacheEvict` 호출
+   - 단일 인스턴스에서는 Caffeine으로 충분
+   - 다중 인스턴스 시 Redis pub/sub 기반 무효화 필요 (0015 참조)
+
+### Phase 2 도입 시점 판단 기준
+
+- Prometheus `http_server_requests_seconds` 지표에서 products/classes 응답이 p95 > 200ms
+- 또는 CloudWatch에서 아웃바운드 비용이 월 $10 이상일 때

--- a/infra/build.gradle
+++ b/infra/build.gradle
@@ -4,10 +4,13 @@ dependencies {
 	implementation project(":app")
 	implementation 'org.springframework.boot:spring-boot-starter-flyway'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'io.micrometer:micrometer-core'
 	implementation 'io.github.resilience4j:resilience4j-circuitbreaker:2.3.0'
 	implementation 'io.github.resilience4j:resilience4j-timelimiter:2.3.0'
 	implementation 'org.flywaydb:flyway-mysql'
+	implementation 'org.mybatis:mybatis:3.5.16'
+	implementation 'org.mybatis:mybatis-spring:3.0.4'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 }

--- a/infra/src/main/java/com/personal/happygallery/infra/dashboard/adapter/MyBatisAdminBookingSearchAdapter.java
+++ b/infra/src/main/java/com/personal/happygallery/infra/dashboard/adapter/MyBatisAdminBookingSearchAdapter.java
@@ -1,0 +1,45 @@
+package com.personal.happygallery.infra.dashboard.adapter;
+
+import com.personal.happygallery.app.search.dto.AdminBookingSearchRow;
+import com.personal.happygallery.app.search.port.out.AdminBookingSearchPort;
+import com.personal.happygallery.domain.booking.BookingStatus;
+import com.personal.happygallery.infra.dashboard.mapper.AdminBookingSearchMapper;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/**
+ * 예약 검색 어댑터.
+ * slots.start_at은 UTC 변환 없이 KST 기준 날짜 범위를 직접 사용한다.
+ * (기존 {@code DefaultAdminBookingQueryService}와 동일한 패턴)
+ */
+@Component
+class MyBatisAdminBookingSearchAdapter implements AdminBookingSearchPort {
+
+    private final AdminBookingSearchMapper mapper;
+
+    MyBatisAdminBookingSearchAdapter(AdminBookingSearchMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public List<AdminBookingSearchRow> search(BookingStatus status, LocalDate dateFrom, LocalDate dateTo,
+                                               String keyword, int offset, int size) {
+        return mapper.search(
+                status != null ? status.name() : null,
+                dateFrom != null ? dateFrom.atStartOfDay() : null,
+                dateTo != null ? dateTo.atTime(LocalTime.MAX) : null,
+                keyword, offset, size);
+    }
+
+    @Override
+    public long count(BookingStatus status, LocalDate dateFrom, LocalDate dateTo, String keyword) {
+        return mapper.count(
+                status != null ? status.name() : null,
+                dateFrom != null ? dateFrom.atStartOfDay() : null,
+                dateTo != null ? dateTo.atTime(LocalTime.MAX) : null,
+                keyword);
+    }
+}

--- a/infra/src/main/java/com/personal/happygallery/infra/dashboard/adapter/MyBatisAdminOrderSearchAdapter.java
+++ b/infra/src/main/java/com/personal/happygallery/infra/dashboard/adapter/MyBatisAdminOrderSearchAdapter.java
@@ -1,0 +1,56 @@
+package com.personal.happygallery.infra.dashboard.adapter;
+
+import com.personal.happygallery.app.search.dto.AdminOrderSearchRow;
+import com.personal.happygallery.app.search.port.out.AdminOrderSearchPort;
+import com.personal.happygallery.domain.order.OrderStatus;
+import com.personal.happygallery.infra.dashboard.mapper.AdminOrderSearchMapper;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/**
+ * KST 날짜 범위를 UTC {@link LocalDateTime}으로 변환한 뒤 MyBatis 매퍼에 전달한다.
+ */
+@Component
+class MyBatisAdminOrderSearchAdapter implements AdminOrderSearchPort {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final AdminOrderSearchMapper mapper;
+
+    MyBatisAdminOrderSearchAdapter(AdminOrderSearchMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public List<AdminOrderSearchRow> search(OrderStatus status, LocalDate dateFrom, LocalDate dateTo,
+                                             String keyword, int offset, int size) {
+        return mapper.search(
+                status != null ? status.name() : null,
+                dateFrom != null ? toUtcStart(dateFrom) : null,
+                dateTo != null ? toUtcEnd(dateTo) : null,
+                keyword, offset, size);
+    }
+
+    @Override
+    public long count(OrderStatus status, LocalDate dateFrom, LocalDate dateTo, String keyword) {
+        return mapper.count(
+                status != null ? status.name() : null,
+                dateFrom != null ? toUtcStart(dateFrom) : null,
+                dateTo != null ? toUtcEnd(dateTo) : null,
+                keyword);
+    }
+
+    /** KST 날짜의 자정(00:00)을 UTC LocalDateTime으로 변환 */
+    private static LocalDateTime toUtcStart(LocalDate kstDate) {
+        return kstDate.atStartOfDay(KST).withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime();
+    }
+
+    /** KST 날짜의 익일 자정(다음날 00:00)을 UTC LocalDateTime으로 변환 — 반개구간 [start, end) */
+    private static LocalDateTime toUtcEnd(LocalDate kstDate) {
+        return kstDate.plusDays(1).atStartOfDay(KST).withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime();
+    }
+}

--- a/infra/src/main/java/com/personal/happygallery/infra/dashboard/adapter/MyBatisBookingStatsAdapter.java
+++ b/infra/src/main/java/com/personal/happygallery/infra/dashboard/adapter/MyBatisBookingStatsAdapter.java
@@ -1,0 +1,36 @@
+package com.personal.happygallery.infra.dashboard.adapter;
+
+import com.personal.happygallery.app.dashboard.dto.SlotUtilization;
+import com.personal.happygallery.app.dashboard.port.out.BookingStatsQueryPort;
+import com.personal.happygallery.infra.dashboard.mapper.BookingStatsMapper;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+class MyBatisBookingStatsAdapter implements BookingStatsQueryPort {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final BookingStatsMapper bookingStatsMapper;
+
+    MyBatisBookingStatsAdapter(BookingStatsMapper bookingStatsMapper) {
+        this.bookingStatsMapper = bookingStatsMapper;
+    }
+
+    @Override
+    public List<SlotUtilization> findSlotUtilization(LocalDate from, LocalDate to) {
+        return bookingStatsMapper.findSlotUtilization(toUtcStart(from), toUtcEnd(to));
+    }
+
+    private static LocalDateTime toUtcStart(LocalDate kstDate) {
+        return kstDate.atStartOfDay(KST).withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime();
+    }
+
+    private static LocalDateTime toUtcEnd(LocalDate kstDate) {
+        return kstDate.plusDays(1).atStartOfDay(KST).withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime();
+    }
+}

--- a/infra/src/main/java/com/personal/happygallery/infra/dashboard/adapter/MyBatisSalesStatsAdapter.java
+++ b/infra/src/main/java/com/personal/happygallery/infra/dashboard/adapter/MyBatisSalesStatsAdapter.java
@@ -1,0 +1,88 @@
+package com.personal.happygallery.infra.dashboard.adapter;
+
+import com.personal.happygallery.app.dashboard.dto.DailyRevenue;
+import com.personal.happygallery.app.dashboard.dto.DashboardOverview;
+import com.personal.happygallery.app.dashboard.dto.Granularity;
+import com.personal.happygallery.app.dashboard.dto.PeriodSalesSummary;
+import com.personal.happygallery.app.dashboard.dto.RefundStats;
+import com.personal.happygallery.app.dashboard.dto.RevenueBreakdown;
+import com.personal.happygallery.app.dashboard.dto.StatusCount;
+import com.personal.happygallery.app.dashboard.dto.TopProduct;
+import com.personal.happygallery.app.dashboard.dto.TopProductSort;
+import com.personal.happygallery.app.dashboard.port.out.SalesStatsQueryPort;
+import com.personal.happygallery.infra.dashboard.mapper.SalesStatsMapper;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/**
+ * KST 날짜 범위를 UTC {@link LocalDateTime}으로 변환한 뒤 MyBatis 매퍼에 전달한다.
+ * WHERE 절에서 인덱스를 탈 수 있도록 sargable 조건을 보장한다.
+ */
+@Component
+class MyBatisSalesStatsAdapter implements SalesStatsQueryPort {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final SalesStatsMapper salesStatsMapper;
+
+    MyBatisSalesStatsAdapter(SalesStatsMapper salesStatsMapper) {
+        this.salesStatsMapper = salesStatsMapper;
+    }
+
+    @Override
+    public DashboardOverview findOverview(LocalDate from, LocalDate to) {
+        LocalDate todayKst = ZonedDateTime.now(KST).toLocalDate();
+        return salesStatsMapper.findOverview(
+                toUtcStart(todayKst), toUtcEnd(todayKst),
+                toUtcStart(from), toUtcEnd(to));
+    }
+
+    @Override
+    public List<PeriodSalesSummary> findSalesSummary(LocalDate from, LocalDate to, Granularity granularity) {
+        return salesStatsMapper.findSalesSummary(toUtcStart(from), toUtcEnd(to), granularity.name());
+    }
+
+    @Override
+    public RevenueBreakdown findRevenueBreakdown(LocalDate from, LocalDate to) {
+        return salesStatsMapper.findRevenueBreakdown(toUtcStart(from), toUtcEnd(to));
+    }
+
+    @Override
+    public List<StatusCount> findOrderStatusDistribution() {
+        return salesStatsMapper.findOrderStatusDistribution();
+    }
+
+    @Override
+    public RefundStats findRefundStats(LocalDate from, LocalDate to) {
+        return salesStatsMapper.findRefundStats(toUtcStart(from), toUtcEnd(to));
+    }
+
+    @Override
+    public List<TopProduct> findTopProducts(LocalDate from, LocalDate to, int limit, TopProductSort sort) {
+        return salesStatsMapper.findTopProducts(toUtcStart(from), toUtcEnd(to), limit, sort.name());
+    }
+
+    @Override
+    public List<DailyRevenue> findDailyRevenueSeries(LocalDate from, LocalDate to) {
+        return salesStatsMapper.findSalesSummary(toUtcStart(from), toUtcEnd(to), Granularity.DAILY.name())
+                .stream()
+                .map(s -> new DailyRevenue(LocalDate.parse(s.periodLabel()), s.totalRevenue()))
+                .toList();
+    }
+
+    /** KST 날짜의 자정(00:00)을 UTC LocalDateTime으로 변환 */
+    private static LocalDateTime toUtcStart(LocalDate kstDate) {
+        return kstDate.atStartOfDay(KST).withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime();
+    }
+
+    /** KST 날짜의 익일 자정(다음날 00:00)을 UTC LocalDateTime으로 변환 — 반개구간 [start, end) */
+    private static LocalDateTime toUtcEnd(LocalDate kstDate) {
+        return kstDate.plusDays(1).atStartOfDay(KST).withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime();
+    }
+}

--- a/infra/src/main/java/com/personal/happygallery/infra/dashboard/config/MyBatisConfig.java
+++ b/infra/src/main/java/com/personal/happygallery/infra/dashboard/config/MyBatisConfig.java
@@ -1,0 +1,30 @@
+package com.personal.happygallery.infra.dashboard.config;
+
+import javax.sql.DataSource;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.SqlSessionFactoryBean;
+import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
+@Configuration
+@MapperScan("com.personal.happygallery.infra.dashboard.mapper")
+public class MyBatisConfig {
+
+    @Bean
+    public SqlSessionFactory sqlSessionFactory(DataSource dataSource) throws Exception {
+        SqlSessionFactoryBean factory = new SqlSessionFactoryBean();
+        factory.setDataSource(dataSource);
+        factory.setMapperLocations(
+                new PathMatchingResourcePatternResolver()
+                        .getResources("classpath:mapper/**/*.xml"));
+
+        org.apache.ibatis.session.Configuration configuration = new org.apache.ibatis.session.Configuration();
+        configuration.setMapUnderscoreToCamelCase(true);
+        configuration.setCacheEnabled(false);
+        factory.setConfiguration(configuration);
+
+        return factory.getObject();
+    }
+}

--- a/infra/src/main/java/com/personal/happygallery/infra/dashboard/mapper/AdminBookingSearchMapper.java
+++ b/infra/src/main/java/com/personal/happygallery/infra/dashboard/mapper/AdminBookingSearchMapper.java
@@ -1,0 +1,25 @@
+package com.personal.happygallery.infra.dashboard.mapper;
+
+import com.personal.happygallery.app.search.dto.AdminBookingSearchRow;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface AdminBookingSearchMapper {
+
+    List<AdminBookingSearchRow> search(
+            @Param("status") String status,
+            @Param("dateFrom") LocalDateTime dateFrom,
+            @Param("dateTo") LocalDateTime dateTo,
+            @Param("keyword") String keyword,
+            @Param("offset") int offset,
+            @Param("size") int size);
+
+    long count(
+            @Param("status") String status,
+            @Param("dateFrom") LocalDateTime dateFrom,
+            @Param("dateTo") LocalDateTime dateTo,
+            @Param("keyword") String keyword);
+}

--- a/infra/src/main/java/com/personal/happygallery/infra/dashboard/mapper/AdminOrderSearchMapper.java
+++ b/infra/src/main/java/com/personal/happygallery/infra/dashboard/mapper/AdminOrderSearchMapper.java
@@ -1,0 +1,25 @@
+package com.personal.happygallery.infra.dashboard.mapper;
+
+import com.personal.happygallery.app.search.dto.AdminOrderSearchRow;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface AdminOrderSearchMapper {
+
+    List<AdminOrderSearchRow> search(
+            @Param("status") String status,
+            @Param("dateFrom") LocalDateTime dateFrom,
+            @Param("dateTo") LocalDateTime dateTo,
+            @Param("keyword") String keyword,
+            @Param("offset") int offset,
+            @Param("size") int size);
+
+    long count(
+            @Param("status") String status,
+            @Param("dateFrom") LocalDateTime dateFrom,
+            @Param("dateTo") LocalDateTime dateTo,
+            @Param("keyword") String keyword);
+}

--- a/infra/src/main/java/com/personal/happygallery/infra/dashboard/mapper/BookingStatsMapper.java
+++ b/infra/src/main/java/com/personal/happygallery/infra/dashboard/mapper/BookingStatsMapper.java
@@ -1,0 +1,14 @@
+package com.personal.happygallery.infra.dashboard.mapper;
+
+import com.personal.happygallery.app.dashboard.dto.SlotUtilization;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface BookingStatsMapper {
+
+    List<SlotUtilization> findSlotUtilization(@Param("rangeFrom") LocalDateTime rangeFrom,
+                                              @Param("rangeTo") LocalDateTime rangeTo);
+}

--- a/infra/src/main/java/com/personal/happygallery/infra/dashboard/mapper/SalesStatsMapper.java
+++ b/infra/src/main/java/com/personal/happygallery/infra/dashboard/mapper/SalesStatsMapper.java
@@ -1,0 +1,38 @@
+package com.personal.happygallery.infra.dashboard.mapper;
+
+import com.personal.happygallery.app.dashboard.dto.DashboardOverview;
+import com.personal.happygallery.app.dashboard.dto.PeriodSalesSummary;
+import com.personal.happygallery.app.dashboard.dto.RefundStats;
+import com.personal.happygallery.app.dashboard.dto.RevenueBreakdown;
+import com.personal.happygallery.app.dashboard.dto.StatusCount;
+import com.personal.happygallery.app.dashboard.dto.TopProduct;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface SalesStatsMapper {
+
+    DashboardOverview findOverview(@Param("todayFrom") LocalDateTime todayFrom,
+                                  @Param("todayTo") LocalDateTime todayTo,
+                                  @Param("rangeFrom") LocalDateTime rangeFrom,
+                                  @Param("rangeTo") LocalDateTime rangeTo);
+
+    List<PeriodSalesSummary> findSalesSummary(@Param("rangeFrom") LocalDateTime rangeFrom,
+                                              @Param("rangeTo") LocalDateTime rangeTo,
+                                              @Param("granularity") String granularity);
+
+    RevenueBreakdown findRevenueBreakdown(@Param("rangeFrom") LocalDateTime rangeFrom,
+                                          @Param("rangeTo") LocalDateTime rangeTo);
+
+    List<StatusCount> findOrderStatusDistribution();
+
+    RefundStats findRefundStats(@Param("rangeFrom") LocalDateTime rangeFrom,
+                                @Param("rangeTo") LocalDateTime rangeTo);
+
+    List<TopProduct> findTopProducts(@Param("rangeFrom") LocalDateTime rangeFrom,
+                                     @Param("rangeTo") LocalDateTime rangeTo,
+                                     @Param("limit") int limit,
+                                     @Param("sort") String sort);
+}

--- a/infra/src/main/java/com/personal/happygallery/infra/notification/KakaoNotificationProperties.java
+++ b/infra/src/main/java/com/personal/happygallery/infra/notification/KakaoNotificationProperties.java
@@ -1,12 +1,16 @@
 package com.personal.happygallery.infra.notification;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.DefaultValue;
+import org.springframework.validation.annotation.Validated;
 
+@Validated
 @ConfigurationProperties(prefix = "app.external.kakao")
 public record KakaoNotificationProperties(
-        String apiKey,
-        String senderKey,
-        @DefaultValue("https://bizapi.kakao.com") String baseUrl,
-        @DefaultValue("5000") long timeoutMillis
+        @NotBlank String apiKey,
+        @NotBlank String senderKey,
+        @NotBlank @DefaultValue("https://bizapi.kakao.com") String baseUrl,
+        @Min(1) @DefaultValue("5000") long timeoutMillis
 ) {}

--- a/infra/src/main/java/com/personal/happygallery/infra/notification/SmsNotificationProperties.java
+++ b/infra/src/main/java/com/personal/happygallery/infra/notification/SmsNotificationProperties.java
@@ -1,13 +1,17 @@
 package com.personal.happygallery.infra.notification;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.DefaultValue;
+import org.springframework.validation.annotation.Validated;
 
+@Validated
 @ConfigurationProperties(prefix = "app.external.sms")
 public record SmsNotificationProperties(
-        String apiKey,
-        String apiSecret,
-        String senderNumber,
-        @DefaultValue("https://api-sms.cloud.toast.com") String baseUrl,
-        @DefaultValue("5000") long timeoutMillis
+        @NotBlank String apiKey,
+        @NotBlank String apiSecret,
+        @NotBlank String senderNumber,
+        @NotBlank @DefaultValue("https://api-sms.cloud.toast.com") String baseUrl,
+        @Min(1) @DefaultValue("5000") long timeoutMillis
 ) {}

--- a/infra/src/main/java/com/personal/happygallery/infra/payment/ExternalPaymentProperties.java
+++ b/infra/src/main/java/com/personal/happygallery/infra/payment/ExternalPaymentProperties.java
@@ -1,18 +1,22 @@
 package com.personal.happygallery.infra.payment;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.DefaultValue;
+import org.springframework.validation.annotation.Validated;
 
+@Validated
 @ConfigurationProperties(prefix = "app.external.payment")
 public record ExternalPaymentProperties(
-        @DefaultValue("3000") long timeoutMillis,
-        CircuitBreaker circuitBreaker
+        @Min(1) @DefaultValue("3000") long timeoutMillis,
+        @Valid CircuitBreaker circuitBreaker
 ) {
     public record CircuitBreaker(
-            @DefaultValue("50") float failureRateThreshold,
-            @DefaultValue("20") int slidingWindowSize,
-            @DefaultValue("10") int minimumNumberOfCalls,
-            @DefaultValue("30") long waitDurationOpenSeconds,
-            @DefaultValue("3") int permittedCallsInHalfOpenState
+            @Min(1) @DefaultValue("50") float failureRateThreshold,
+            @Min(1) @DefaultValue("20") int slidingWindowSize,
+            @Min(1) @DefaultValue("10") int minimumNumberOfCalls,
+            @Min(1) @DefaultValue("30") long waitDurationOpenSeconds,
+            @Min(1) @DefaultValue("3") int permittedCallsInHalfOpenState
     ) {}
 }

--- a/infra/src/main/resources/mapper/AdminBookingSearchMapper.xml
+++ b/infra/src/main/resources/mapper/AdminBookingSearchMapper.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.personal.happygallery.infra.dashboard.mapper.AdminBookingSearchMapper">
+
+    <!-- search / count 공유 WHERE 프래그먼트 -->
+    <sql id="searchConditions">
+        <where>
+            <if test="status != null">
+                AND b.status = #{status}
+            </if>
+            <if test="dateFrom != null">
+                AND s.start_at &gt;= #{dateFrom}
+            </if>
+            <if test="dateTo != null">
+                AND s.start_at &lt; #{dateTo}
+            </if>
+            <if test="keyword != null and keyword != ''">
+                AND (
+                    CAST(b.id AS CHAR) LIKE CONCAT('%', #{keyword}, '%')
+                    OR u.name LIKE CONCAT('%', #{keyword}, '%')
+                    OR g.name LIKE CONCAT('%', #{keyword}, '%')
+                )
+            </if>
+        </where>
+    </sql>
+
+    <!--
+        지연 조인(Deferred Join):
+        서브쿼리에서 커버링 인덱스로 ID만 페이징한 뒤,
+        외부 쿼리에서 실제 데이터를 JOIN으로 가져온다.
+        예약은 날짜 필터가 slots.start_at 기준이므로 서브쿼리에 항상 slots JOIN 포함.
+    -->
+    <select id="search" resultType="com.personal.happygallery.app.search.dto.AdminBookingSearchRow">
+        SELECT
+            b.id                                                              AS bookingId,
+            CONCAT('BK-', LPAD(b.id, 8, '0'))                                AS bookingNumber,
+            CASE WHEN b.user_id IS NOT NULL THEN 'MEMBER' ELSE 'GUEST' END   AS bookerType,
+            COALESCE(u.name, g.name, '(알 수 없음)')                           AS bookerName,
+            COALESCE(u.phone, g.phone, '')                                    AS bookerPhone,
+            c.name                                                            AS className,
+            s.start_at                                                        AS startAt,
+            s.end_at                                                          AS endAt,
+            b.status                                                          AS status,
+            b.deposit_amount                                                  AS depositAmount,
+            b.balance_amount                                                  AS balanceAmount,
+            CASE WHEN b.pass_purchase_id IS NOT NULL THEN TRUE ELSE FALSE END AS passBooking,
+            b.created_at                                                      AS createdAt
+        FROM bookings b
+        INNER JOIN (
+            SELECT b.id
+            FROM bookings b
+            JOIN slots s ON b.slot_id = s.id
+            <if test="keyword != null and keyword != ''">
+                LEFT JOIN users u ON b.user_id = u.id
+                LEFT JOIN guests g ON b.guest_id = g.id
+            </if>
+            <include refid="searchConditions"/>
+            ORDER BY b.created_at DESC
+            LIMIT #{size} OFFSET #{offset}
+        ) sub ON b.id = sub.id
+        JOIN slots s ON b.slot_id = s.id
+        JOIN classes c ON b.class_id = c.id
+        LEFT JOIN users u ON b.user_id = u.id
+        LEFT JOIN guests g ON b.guest_id = g.id
+        ORDER BY b.created_at DESC
+    </select>
+
+    <select id="count" resultType="long">
+        SELECT COUNT(*)
+        FROM bookings b
+        JOIN slots s ON b.slot_id = s.id
+        <if test="keyword != null and keyword != ''">
+            LEFT JOIN users u ON b.user_id = u.id
+            LEFT JOIN guests g ON b.guest_id = g.id
+        </if>
+        <include refid="searchConditions"/>
+    </select>
+
+</mapper>

--- a/infra/src/main/resources/mapper/AdminOrderSearchMapper.xml
+++ b/infra/src/main/resources/mapper/AdminOrderSearchMapper.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.personal.happygallery.infra.dashboard.mapper.AdminOrderSearchMapper">
+
+    <!-- search / count 공유 WHERE 프래그먼트 -->
+    <sql id="searchConditions">
+        <where>
+            <if test="status != null">
+                AND o.status = #{status}
+            </if>
+            <if test="dateFrom != null">
+                AND o.created_at &gt;= #{dateFrom}
+            </if>
+            <if test="dateTo != null">
+                AND o.created_at &lt; #{dateTo}
+            </if>
+            <if test="keyword != null and keyword != ''">
+                AND (
+                    CAST(o.id AS CHAR) LIKE CONCAT('%', #{keyword}, '%')
+                    OR u.name LIKE CONCAT('%', #{keyword}, '%')
+                    OR g.name LIKE CONCAT('%', #{keyword}, '%')
+                )
+            </if>
+        </where>
+    </sql>
+
+    <!--
+        지연 조인(Deferred Join):
+        서브쿼리에서 커버링 인덱스로 ID만 페이징한 뒤,
+        외부 쿼리에서 실제 데이터를 JOIN으로 가져온다.
+    -->
+    <select id="search" resultType="com.personal.happygallery.app.search.dto.AdminOrderSearchRow">
+        SELECT
+            o.id                                    AS orderId,
+            CONCAT('ORD-', LPAD(o.id, 8, '0'))      AS orderNumber,
+            o.status                                AS status,
+            o.total_amount                          AS totalAmount,
+            COALESCE(u.name, g.name, '(알 수 없음)')  AS buyerName,
+            COALESCE(u.phone, g.phone, '')           AS buyerPhone,
+            o.paid_at                               AS paidAt,
+            o.approval_deadline_at                  AS approvalDeadlineAt,
+            o.created_at                            AS createdAt
+        FROM orders o
+        INNER JOIN (
+            SELECT o.id
+            FROM orders o
+            <if test="keyword != null and keyword != ''">
+                LEFT JOIN users u ON o.user_id = u.id
+                LEFT JOIN guests g ON o.guest_id = g.id
+            </if>
+            <include refid="searchConditions"/>
+            ORDER BY o.created_at DESC
+            LIMIT #{size} OFFSET #{offset}
+        ) sub ON o.id = sub.id
+        LEFT JOIN users u ON o.user_id = u.id
+        LEFT JOIN guests g ON o.guest_id = g.id
+        ORDER BY o.created_at DESC
+    </select>
+
+    <select id="count" resultType="long">
+        SELECT COUNT(*)
+        FROM orders o
+        <if test="keyword != null and keyword != ''">
+            LEFT JOIN users u ON o.user_id = u.id
+            LEFT JOIN guests g ON o.guest_id = g.id
+        </if>
+        <include refid="searchConditions"/>
+    </select>
+
+</mapper>

--- a/infra/src/main/resources/mapper/BookingStatsMapper.xml
+++ b/infra/src/main/resources/mapper/BookingStatsMapper.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.personal.happygallery.infra.dashboard.mapper.BookingStatsMapper">
+
+    <select id="findSlotUtilization" resultType="com.personal.happygallery.app.dashboard.dto.SlotUtilization">
+        SELECT
+            DATE(CONVERT_TZ(s.start_at, '+00:00', '+09:00')) AS date,
+            c.name                                            AS className,
+            SUM(s.capacity)                                   AS totalCapacity,
+            SUM(s.booked_count)                               AS totalBooked,
+            ROUND(SUM(s.booked_count) / NULLIF(SUM(s.capacity), 0), 4) AS utilizationRate
+        FROM slots s
+            JOIN classes c ON s.class_id = c.id
+        WHERE s.is_active = TRUE
+          AND s.start_at >= #{rangeFrom} AND s.start_at &lt; #{rangeTo}
+        GROUP BY date, c.name
+        ORDER BY date, c.name
+    </select>
+
+</mapper>

--- a/infra/src/main/resources/mapper/SalesStatsMapper.xml
+++ b/infra/src/main/resources/mapper/SalesStatsMapper.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.personal.happygallery.infra.dashboard.mapper.SalesStatsMapper">
+
+    <!-- 환불/거절/만료 등 실 매출에서 제외할 상태 (OrderStatus.isRefunded 참조) -->
+    <sql id="excludedOrderStatuses">
+        'REJECTED', 'AUTO_REFUND_TIMEOUT', 'PICKUP_EXPIRED'
+    </sql>
+
+    <select id="findOverview" resultType="com.personal.happygallery.app.dashboard.dto.DashboardOverview">
+        SELECT
+            COALESCE(ord.todayRevenue, 0)   AS todayRevenue,
+            COALESCE(ord.todayOrderCount, 0) AS todayOrderCount,
+            COALESCE(pending.cnt, 0)         AS pendingApprovalCount,
+            COALESCE(today_bk.cnt, 0)        AS todayBookingCount,
+            COALESCE(ord.monthRevenue, 0)    AS monthRevenue,
+            COALESCE(ord.monthOrderCount, 0) AS monthOrderCount
+        FROM
+            (SELECT
+                 SUM(CASE WHEN paid_at >= #{todayFrom} AND paid_at &lt; #{todayTo}
+                          THEN total_amount END) AS todayRevenue,
+                 SUM(CASE WHEN paid_at >= #{todayFrom} AND paid_at &lt; #{todayTo}
+                          THEN 1 ELSE 0 END)     AS todayOrderCount,
+                 SUM(total_amount)                AS monthRevenue,
+                 COUNT(*)                         AS monthOrderCount
+             FROM orders
+             WHERE paid_at IS NOT NULL
+               AND status NOT IN (<include refid="excludedOrderStatuses"/>)
+               AND paid_at >= #{rangeFrom} AND paid_at &lt; #{rangeTo}
+            ) ord,
+            (SELECT COUNT(*) AS cnt
+             FROM orders
+             WHERE status = 'PAID_APPROVAL_PENDING'
+            ) pending,
+            (SELECT COUNT(*) AS cnt
+             FROM bookings
+             WHERE status = 'BOOKED'
+               AND created_at >= #{todayFrom} AND created_at &lt; #{todayTo}
+            ) today_bk
+    </select>
+
+    <select id="findSalesSummary" resultType="com.personal.happygallery.app.dashboard.dto.PeriodSalesSummary">
+        SELECT
+            <choose>
+                <when test="granularity == 'DAILY'">
+                    DATE_FORMAT(CONVERT_TZ(o.paid_at, '+00:00', '+09:00'), '%Y-%m-%d')
+                </when>
+                <when test="granularity == 'WEEKLY'">
+                    DATE_FORMAT(CONVERT_TZ(o.paid_at, '+00:00', '+09:00'), '%x-W%v')
+                </when>
+                <when test="granularity == 'MONTHLY'">
+                    DATE_FORMAT(CONVERT_TZ(o.paid_at, '+00:00', '+09:00'), '%Y-%m')
+                </when>
+            </choose> AS periodLabel,
+            COALESCE(SUM(o.total_amount), 0) AS totalRevenue,
+            COUNT(*)                         AS orderCount,
+            COALESCE(AVG(o.total_amount), 0) AS avgOrderValue
+        FROM orders o
+        WHERE o.paid_at IS NOT NULL
+          AND o.status NOT IN (<include refid="excludedOrderStatuses"/>)
+          AND o.paid_at >= #{rangeFrom} AND o.paid_at &lt; #{rangeTo}
+        GROUP BY periodLabel
+        ORDER BY periodLabel
+    </select>
+
+    <select id="findRevenueBreakdown" resultType="com.personal.happygallery.app.dashboard.dto.RevenueBreakdown">
+        SELECT
+            COALESCE(ord.rev, 0)  AS orderRevenue,
+            COALESCE(dep.rev, 0)  AS bookingDepositRevenue,
+            COALESCE(bal.rev, 0)  AS bookingBalanceRevenue,
+            COALESCE(pp.rev, 0)   AS passPurchaseRevenue,
+            (COALESCE(ord.rev, 0) + COALESCE(dep.rev, 0)
+                + COALESCE(bal.rev, 0) + COALESCE(pp.rev, 0)) AS totalRevenue
+        FROM
+            (SELECT SUM(total_amount) AS rev
+             FROM orders
+             WHERE paid_at IS NOT NULL
+               AND status NOT IN (<include refid="excludedOrderStatuses"/>)
+               AND paid_at >= #{rangeFrom} AND paid_at &lt; #{rangeTo}
+            ) ord,
+            (SELECT SUM(deposit_amount) AS rev
+             FROM bookings
+             WHERE status != 'CANCELED'
+               AND deposit_paid_at IS NOT NULL
+               AND deposit_paid_at >= #{rangeFrom} AND deposit_paid_at &lt; #{rangeTo}
+            ) dep,
+            (SELECT SUM(balance_amount) AS rev
+             FROM bookings
+             WHERE balance_status = 'PAID'
+               AND created_at >= #{rangeFrom} AND created_at &lt; #{rangeTo}
+            ) bal,
+            (SELECT SUM(total_price) AS rev
+             FROM pass_purchases
+             WHERE purchased_at >= #{rangeFrom} AND purchased_at &lt; #{rangeTo}
+            ) pp
+    </select>
+
+    <select id="findOrderStatusDistribution" resultType="com.personal.happygallery.app.dashboard.dto.StatusCount">
+        SELECT status, COUNT(*) AS count
+        FROM orders
+        GROUP BY status
+        ORDER BY count DESC
+    </select>
+
+    <select id="findRefundStats" resultType="com.personal.happygallery.app.dashboard.dto.RefundStats">
+        SELECT
+            COUNT(*)                         AS totalRefundCount,
+            COALESCE(SUM(r.amount), 0)       AS totalRefundedAmount,
+            ROUND(
+                COUNT(*) / NULLIF(
+                    (SELECT COUNT(*) FROM orders
+                     WHERE paid_at IS NOT NULL
+                       AND paid_at >= #{rangeFrom} AND paid_at &lt; #{rangeTo}
+                    ), 0
+                ), 4
+            ) AS refundRate
+        FROM refunds r
+        WHERE r.status = 'SUCCEEDED'
+          AND r.created_at >= #{rangeFrom} AND r.created_at &lt; #{rangeTo}
+    </select>
+
+    <select id="findTopProducts" resultType="com.personal.happygallery.app.dashboard.dto.TopProduct">
+        SELECT
+            p.id                        AS productId,
+            p.name                      AS productName,
+            p.type                      AS productType,
+            SUM(oi.unit_price * oi.qty) AS totalRevenue,
+            SUM(oi.qty)                 AS totalQuantity
+        FROM order_items oi
+            JOIN orders o ON oi.order_id = o.id
+            JOIN products p ON oi.product_id = p.id
+        WHERE o.paid_at IS NOT NULL
+          AND o.status NOT IN (<include refid="excludedOrderStatuses"/>)
+          AND o.paid_at >= #{rangeFrom} AND o.paid_at &lt; #{rangeTo}
+        GROUP BY p.id, p.name, p.type
+        ORDER BY
+            <choose>
+                <when test="sort == 'REVENUE'">totalRevenue DESC</when>
+                <when test="sort == 'QUANTITY'">totalQuantity DESC</when>
+            </choose>
+        LIMIT #{limit}
+    </select>
+
+</mapper>


### PR DESCRIPTION
## 문제\n- codexReview에 반영된 관리자 검색/통계 개선, 배치 반복 페이징 보정, ETag 캐시 설정 정리가 main에는 아직 반영되지 않았습니다.\n\n## 핵심 설계 판단\n- 관리자 주문·예약 검색과 매출 통계는 MyBatis 기반 조회 API로 분리해 복잡한 조회를 명시적으로 다룹니다.\n- BatchExecutor 반복 페이징은 중복 재처리를 막도록 보정했고, 환불 보조 로직과 낙관적 락 재시도 메타 어노테이션을 공통화했습니다.\n- HTTP 캐싱은 ETag 필터 설정과 검토 문서까지 함께 반영해 후속 확장 기준을 남겼습니다.\n\n## 실행한 테스트\n- 현재 PR 생성 전 로컬 워크트리는 깨끗한 상태입니다.\n\n## 문서 반영 여부\n- 관련 아이디어 문서 반영 포함