### PR TITLE
리팩터링: 알림 이벤트 전환과 예약-패스 경계 정리

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,6 +1,6 @@
 # HANDOFF.md
 > 다음 세션을 위한 인수인계 문서.
-> 작성 시점: 2026-03-28 (회원 장바구니/소셜 로그인 반영 상태)
+> 작성 시점: 2026-04-02 (알림 이벤트 전환/예약-패스 경계 정리 반영 상태)
 
 ---
 
@@ -22,6 +22,10 @@
 
 - 권장 작업 브랜치: `codex/work-20260321-guest-pass-cleanup`
 - 최근 작업:
+  - 알림 발송 흐름 정리 — `NotificationRequestedEvent` + `NotificationEventListener`를 추가해 주문/예약/배치에서 알림 요청을 트랜잭션 커밋 후 비동기 이벤트로 발행하도록 바꿨다. `NotificationService`의 기존 `@Async` 메서드는 하위 호환용으로 유지하되 신규 호출은 event publisher 기준으로 모은다
+  - 예약/패스 경계 정리 — 예약 생성/취소 쪽의 8회권 크레딧 차감·복구를 `PassCreditPort`로 위임했고, pass 환불 시 미래 예약 일괄 취소는 `BookingCancellationPort`로 넘겼다. 관리자 no-show 유스케이스도 `PassNoShowUseCase` 대신 `BookingNoShowUseCase`로 이름과 소속을 바로잡았다
+  - 조회/응답 조립 정리 — 장바구니 checkout은 `CartCheckoutUseCase`를 통해 주입하고, 관리자 Q&A/문의 답변은 `replyAndGet`으로 저장과 응답 조립을 한 번에 처리하도록 정리했다
+  - README 동기화 — 실제 멀티 모듈 구성을 `app/domain/infra`로 바로잡고, 관리자 검색/대시보드 집계에 MyBatis를 쓰는 점을 README에 명시했다
   - 외부 HTTP 풀링 기준선 추가 — `prod` 프로필의 Kakao/SMS/Google OAuth `RestClient`를 서비스별 Apache HttpClient 5 풀로 분리했다. 기본값은 `acquire 1s`, `connect 2s`, `read 5s`, `keep-alive 30s`이며, 알림은 max 20, Google OAuth는 max 10으로 시작한다. 상세 의사결정은 ADR-0029를 참고한다
   - timeout 기준선 정리 — 프론트 fetch timeout을 35초, nginx `proxy_read_timeout`을 30초, Hikari acquire timeout을 2초, 기본 트랜잭션 timeout을 10초, JPA query timeout을 5초, MySQL `innodb_lock_wait_timeout` 세션값을 3초로 맞췄다. 외부 알림/OAuth 호출은 read 5초를 유지하면서 acquire 1초, connect 2초, keep-alive 30초, 서비스별 max connections 기준을 추가했고, 동기 MVC 전체 요청 deadline은 별도 필터/컨테이너 커스터마이저 후보로 남겼다. 상세 의사결정은 ADR-0030과 ADR-0029를 참고한다
   - ingress keep-alive 기준선 추가 — `nginx`는 `client -> nginx keepalive_timeout 15s`를 명시하고, `nginx -> app`은 upstream keep-alive를 켰다. 이 hop에서는 caller가 먼저 연결을 정리하고 callee가 더 오래 유지하도록 시작값을 맞춘다. 상세 의사결정은 ADR-0030을 참고한다

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 - **백엔드**: Spring Boot 4.0.2 / Java 21 / MySQL 8
 - **프론트엔드**: Vite / React 19 / TypeScript / Bootstrap
-- **구조**: Gradle 멀티 모듈(`app` · `domain` · `infra` · `common`) + `frontend/` 워크스페이스
+- **구조**: Gradle 멀티 모듈(`app` · `domain` · `infra`) + `frontend/` 워크스페이스
 
 ---
 
@@ -15,10 +15,11 @@
 
 | 구분 | 구성 | 용도 |
 |------|------|------|
-| 백엔드 구조 | `app` / `domain` / `infra` / `common` | 진입점, 도메인 규칙, 외부 연동을 나눈 멀티 모듈 구조다. `app` 안에서는 유스케이스 입력 인터페이스와 저장/외부 연동 인터페이스를 조금씩 분리하고 있다. |
+| 백엔드 구조 | `app` / `domain` / `infra` | 진입점, 도메인 규칙, 외부 연동을 나눈 멀티 모듈 구조다. `app` 안에서는 유스케이스 입력 인터페이스와 저장/외부 연동 인터페이스를 조금씩 분리하고 있다. |
 | 관측성 구조 | `monitoring/` + `docker-compose.yml` | Prometheus, Grafana, alert rule, 대시보드 설정을 로컬에서 바로 띄울 수 있게 묶어 둔다. |
 | Resilience4j | `resilience4j-circuitbreaker`, `resilience4j-timelimiter` | PG 환불 호출에 circuit breaker와 timeout을 적용해 장애 전파를 줄인다. |
 | Redis + Spring Session | `spring-boot-starter-data-redis`, `spring-session-data-redis` | 회원 세션(`HG_SESSION`), 관리자 Bearer 세션, 요청 제한 카운터를 Redis에 저장한다. |
+| JPA + MyBatis | `spring-boot-starter-data-jpa`, `mybatis`, `mybatis-spring` | 일반 영속성은 JPA로 처리하고, 관리자 주문/예약 검색과 관리자 대시보드 집계 쿼리는 MyBatis mapper로 분리해 최적화한다. |
 | HTTP 캐시 | `ShallowEtagHeaderFilter` | 공개 상품/클래스/공지 GET 응답에 `ETag`를 붙이고 `If-None-Match` 기반 `304 Not Modified`를 지원한다. |
 | Flyway | `spring-boot-starter-flyway`, `flyway-mysql` | MySQL 스키마 변경을 버전으로 관리한다. |
 | Spring Actuator | `spring-boot-starter-actuator` | 헬스 체크와 메트릭 엔드포인트를 제공한다. |
@@ -46,6 +47,7 @@
 - 관리자 세션과 요청 제한: 관리자 Bearer 세션과 rate limit 카운터를 각 서버 메모리 대신 Redis에 저장한다. 여러 인스턴스가 떠 있어도 같은 제한값을 공유한다.
 - 유스케이스 진입점: 회원 인증과 guest claim부터 시작해 예약 변경/취소, 8회권 만료 배치, 픽업 만료 배치도 유스케이스 인터페이스를 통해 호출하도록 정리했다.
 - 인터페이스 분리: 상품, 알림, 결제, 예약, 주문 영역에서 조회/저장/외부 연동 인터페이스를 나눴다. JPA와 외부 연동 구현은 별도 구현 클래스로 둔다.
+- 관리자 검색/집계: 관리자 주문/예약 검색과 매출/환불/가동률 대시보드 조회는 `infra`의 MyBatis adapter + mapper로 처리한다.
 - 8회권: guest 소유 8회권을 없애고 회원 전용 구매로 단일화했다. `pass_purchases.guest_id`도 제거했다.
 - guest 토큰: URL query와 평문 저장을 걷어내고 `X-Access-Token` 헤더 + SHA-256 해시 저장으로 바꿨다.
 - 로그: `prod`는 JSON 구조화 로그를 쓰고, `local`/`test`는 읽기 쉬운 텍스트 로그를 유지한다. 전화번호, Bearer 토큰, 세션 토큰, access token은 로그 출력 전에 마스킹한다.
@@ -180,9 +182,7 @@
 - `domain/`
   - 엔티티, 상태 전이, 정책 등 핵심 비즈니스 규칙
 - `infra/`
-  - JPA 리포지토리와 persistence/external adapter, 결제/알림/세션/모니터링 등 외부 연동 구현
-- `common/`
-  - 공통 예외, 시간 유틸, 공용 타입
+  - JPA 리포지토리와 MyBatis mapper/adapter, 결제/알림/세션/모니터링 등 외부 연동 구현
 - `monitoring/`
   - Prometheus scrape/alert rule, Grafana datasource/provisioning, 대시보드 JSON
 - `frontend/`

--- a/app/src/main/java/com/personal/happygallery/app/booking/BookingSlotSupport.java
+++ b/app/src/main/java/com/personal/happygallery/app/booking/BookingSlotSupport.java
@@ -2,9 +2,7 @@ package com.personal.happygallery.app.booking;
 
 import com.personal.happygallery.app.booking.port.out.BookingStorePort;
 import com.personal.happygallery.app.booking.port.out.SlotReaderPort;
-import com.personal.happygallery.app.pass.port.out.PassLedgerStorePort;
-import com.personal.happygallery.app.pass.port.out.PassPurchaseReaderPort;
-import com.personal.happygallery.app.pass.port.out.PassPurchaseStorePort;
+import com.personal.happygallery.app.pass.port.in.PassCreditPort;
 import com.personal.happygallery.domain.error.NotFoundException;
 import com.personal.happygallery.domain.error.PaymentMethodNotAllowedException;
 import com.personal.happygallery.domain.error.SlotNotAvailableException;
@@ -13,12 +11,8 @@ import com.personal.happygallery.domain.booking.BookingHistoryAction;
 import com.personal.happygallery.domain.booking.DepositPaymentMethod;
 import com.personal.happygallery.domain.booking.Slot;
 import com.personal.happygallery.domain.notification.NotificationEventType;
-import com.personal.happygallery.domain.pass.PassLedger;
-import com.personal.happygallery.domain.pass.PassLedgerType;
 import com.personal.happygallery.domain.pass.PassPurchase;
 import java.time.Clock;
-import java.time.LocalDateTime;
-import java.util.Objects;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,26 +29,20 @@ class BookingSlotSupport {
     private final SlotReaderPort slotReaderPort;
     private final SlotBookingCoordinator slotBookingCoordinator;
     private final BookingStorePort bookingStorePort;
-    private final PassPurchaseReaderPort passPurchaseReaderPort;
-    private final PassPurchaseStorePort passPurchaseStorePort;
-    private final PassLedgerStorePort passLedgerStorePort;
+    private final PassCreditPort passCreditPort;
     private final BookingSupport bookingSupport;
     private final Clock clock;
 
     BookingSlotSupport(SlotReaderPort slotReaderPort,
                        SlotBookingCoordinator slotBookingCoordinator,
                        BookingStorePort bookingStorePort,
-                       PassPurchaseReaderPort passPurchaseReaderPort,
-                       PassPurchaseStorePort passPurchaseStorePort,
-                       PassLedgerStorePort passLedgerStorePort,
+                       PassCreditPort passCreditPort,
                        BookingSupport bookingSupport,
                        Clock clock) {
         this.slotReaderPort = slotReaderPort;
         this.slotBookingCoordinator = slotBookingCoordinator;
         this.bookingStorePort = bookingStorePort;
-        this.passPurchaseReaderPort = passPurchaseReaderPort;
-        this.passPurchaseStorePort = passPurchaseStorePort;
-        this.passLedgerStorePort = passLedgerStorePort;
+        this.passCreditPort = passCreditPort;
         this.bookingSupport = bookingSupport;
         this.clock = clock;
     }
@@ -82,7 +70,7 @@ class BookingSlotSupport {
     }
 
     /**
-     * 8회권 크레딧 차감: 조회 → (ownerUserId가 non-null이면 소유자 확인) → usable 검증 → ledger → useCredit.
+     * 8회권 크레딧 차감을 PassCreditPort에 위임한다.
      *
      * @param passId       8회권 ID
      * @param ownerUserId  소유자 회원 ID (회원 예약일 때 non-null, 게스트 예약일 때 null)
@@ -90,18 +78,7 @@ class BookingSlotSupport {
      */
     @Transactional(propagation = Propagation.MANDATORY)
     PassPurchase deductPassCredit(Long passId, Long ownerUserId) {
-        PassPurchase pass = passPurchaseReaderPort.findById(passId)
-                .orElseThrow(() -> new NotFoundException("8회권"));
-
-        if (ownerUserId != null && !Objects.equals(pass.getUserId(), ownerUserId)) {
-            throw new NotFoundException("8회권");
-        }
-
-        pass.requireUsable(LocalDateTime.now(clock));
-        passLedgerStorePort.save(new PassLedger(pass, PassLedgerType.USE, 1));
-        pass.useCredit();
-        passPurchaseStorePort.save(pass);
-        return pass;
+        return passCreditPort.deductCredit(passId, ownerUserId);
     }
 
     /** 예약금 결제 수단 검증 — 계좌이체 차단. */

--- a/app/src/main/java/com/personal/happygallery/app/booking/BookingSupport.java
+++ b/app/src/main/java/com/personal/happygallery/app/booking/BookingSupport.java
@@ -2,7 +2,6 @@ package com.personal.happygallery.app.booking;
 
 import com.personal.happygallery.app.booking.port.out.BookingHistoryPort;
 import com.personal.happygallery.app.booking.port.out.BookingReaderPort;
-import com.personal.happygallery.app.notification.NotificationService;
 import com.personal.happygallery.domain.error.NotFoundException;
 import com.personal.happygallery.app.token.GuestTokenService;
 import com.personal.happygallery.domain.booking.Booking;
@@ -10,7 +9,9 @@ import com.personal.happygallery.domain.booking.BookingHistory;
 import com.personal.happygallery.domain.booking.BookingHistoryAction;
 import com.personal.happygallery.domain.booking.Slot;
 import com.personal.happygallery.domain.notification.NotificationEventType;
+import com.personal.happygallery.domain.notification.NotificationRequestedEvent;
 import java.util.Objects;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,16 +21,16 @@ class BookingSupport {
 
     private final BookingReaderPort bookingReaderPort;
     private final BookingHistoryPort bookingHistoryPort;
-    private final NotificationService notificationService;
+    private final ApplicationEventPublisher eventPublisher;
     private final GuestTokenService guestTokenService;
 
     BookingSupport(BookingReaderPort bookingReaderPort,
                    BookingHistoryPort bookingHistoryPort,
-                   NotificationService notificationService,
+                   ApplicationEventPublisher eventPublisher,
                    GuestTokenService guestTokenService) {
         this.bookingReaderPort = bookingReaderPort;
         this.bookingHistoryPort = bookingHistoryPort;
-        this.notificationService = notificationService;
+        this.eventPublisher = eventPublisher;
         this.guestTokenService = guestTokenService;
     }
 
@@ -55,13 +56,13 @@ class BookingSupport {
     /** booking 의 guest/member 를 자동 판별하여 알림을 발송한다. */
     void notifyBooker(Booking booking, NotificationEventType eventType) {
         if (booking.getUserId() != null) {
-            notificationService.notifyByUserId(booking.getUserId(), eventType);
+            eventPublisher.publishEvent(NotificationRequestedEvent.forUser(booking.getUserId(), eventType));
         } else if (booking.getGuest() != null) {
-            notificationService.notifyGuest(
+            eventPublisher.publishEvent(NotificationRequestedEvent.forGuestWithContact(
                     booking.getGuest().getId(),
                     booking.getGuest().getPhone(),
                     booking.getGuest().getName(),
-                    eventType);
+                    eventType));
         }
     }
 }

--- a/app/src/main/java/com/personal/happygallery/app/booking/DefaultBookingCancelService.java
+++ b/app/src/main/java/com/personal/happygallery/app/booking/DefaultBookingCancelService.java
@@ -2,9 +2,8 @@ package com.personal.happygallery.app.booking;
 
 import com.personal.happygallery.app.booking.port.in.BookingCancelUseCase;
 import com.personal.happygallery.app.booking.port.out.BookingStorePort;
+import com.personal.happygallery.app.pass.port.in.PassCreditPort;
 import com.personal.happygallery.app.payment.RefundExecutionService;
-import com.personal.happygallery.app.pass.port.out.PassLedgerStorePort;
-import com.personal.happygallery.app.pass.port.out.PassPurchaseStorePort;
 import com.personal.happygallery.domain.time.TimeBoundary;
 import com.personal.happygallery.domain.booking.Booking;
 import com.personal.happygallery.domain.booking.BookingHistoryAction;
@@ -12,9 +11,6 @@ import com.personal.happygallery.domain.booking.Refund;
 import com.personal.happygallery.domain.booking.Slot;
 import com.personal.happygallery.domain.notification.NotificationEventType;
 import com.personal.happygallery.domain.payment.RefundStatus;
-import com.personal.happygallery.domain.pass.PassLedger;
-import com.personal.happygallery.domain.pass.PassLedgerType;
-import com.personal.happygallery.domain.pass.PassPurchase;
 import java.time.Clock;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,23 +21,20 @@ public class DefaultBookingCancelService implements BookingCancelUseCase {
 
     private final BookingStorePort bookingStorePort;
     private final RefundExecutionService refundExecutionService;
-    private final PassPurchaseStorePort passPurchaseStorePort;
-    private final PassLedgerStorePort passLedgerStorePort;
+    private final PassCreditPort passCreditPort;
     private final BookingSlotSupport creationSupport;
     private final BookingSupport bookingSupport;
     private final Clock clock;
 
     public DefaultBookingCancelService(BookingStorePort bookingStorePort,
                                 RefundExecutionService refundExecutionService,
-                                PassPurchaseStorePort passPurchaseStorePort,
-                                PassLedgerStorePort passLedgerStorePort,
+                                PassCreditPort passCreditPort,
                                 BookingSlotSupport creationSupport,
                                 BookingSupport bookingSupport,
                                 Clock clock) {
         this.bookingStorePort = bookingStorePort;
         this.refundExecutionService = refundExecutionService;
-        this.passPurchaseStorePort = passPurchaseStorePort;
-        this.passLedgerStorePort = passLedgerStorePort;
+        this.passCreditPort = passCreditPort;
         this.creationSupport = creationSupport;
         this.bookingSupport = bookingSupport;
         this.clock = clock;
@@ -105,17 +98,13 @@ public class DefaultBookingCancelService implements BookingCancelUseCase {
             return new CancellationCompensation(true, false);
         }
 
-        Refund refund = refundExecutionService.processBookingRefund(booking.getId(), booking.getDepositAmount());
+        Refund refund = refundExecutionService.processBookingRefund(booking, booking.getDepositAmount());
         boolean depositRefundSucceeded = refund.getStatus() == RefundStatus.SUCCEEDED;
         return new CancellationCompensation(true, depositRefundSucceeded);
     }
 
     private void restorePassCredit(Booking booking) {
-        PassPurchase pass = booking.getPassPurchase();
-        passLedgerStorePort.save(
-                new PassLedger(pass, PassLedgerType.REFUND, 1, booking.getId()));
-        pass.refundCredit();
-        passPurchaseStorePort.save(pass);
+        passCreditPort.restoreCredit(booking.getPassPurchase().getId(), booking.getId());
     }
 
     private record CancellationCompensation(boolean refundable, boolean depositRefundSucceeded) {}

--- a/app/src/main/java/com/personal/happygallery/app/booking/DefaultBookingCancellationService.java
+++ b/app/src/main/java/com/personal/happygallery/app/booking/DefaultBookingCancellationService.java
@@ -1,0 +1,69 @@
+package com.personal.happygallery.app.booking;
+
+import com.personal.happygallery.app.booking.port.in.BookingCancellationPort;
+import com.personal.happygallery.app.booking.port.out.BookingReaderPort;
+import com.personal.happygallery.app.booking.port.out.BookingStorePort;
+import com.personal.happygallery.domain.booking.Booking;
+import com.personal.happygallery.domain.booking.BookingHistoryAction;
+import com.personal.happygallery.domain.booking.BookingStatus;
+import com.personal.happygallery.domain.booking.Slot;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Pass 환불 시 연동 예약 일괄 취소를 처리하는 도메인 서비스.
+ *
+ * <p>Pass 도메인이 Booking 내부 Port를 직접 참조하지 않도록
+ * {@link BookingCancellationPort}를 구현한다.
+ */
+@Service
+@Transactional
+class DefaultBookingCancellationService implements BookingCancellationPort {
+
+    private static final Logger log = LoggerFactory.getLogger(DefaultBookingCancellationService.class);
+
+    private final BookingReaderPort bookingReader;
+    private final BookingStorePort bookingStore;
+    private final BookingSlotSupport slotSupport;
+    private final BookingSupport bookingSupport;
+    private final Clock clock;
+
+    DefaultBookingCancellationService(BookingReaderPort bookingReader,
+                                      BookingStorePort bookingStore,
+                                      BookingSlotSupport slotSupport,
+                                      BookingSupport bookingSupport,
+                                      Clock clock) {
+        this.bookingReader = bookingReader;
+        this.bookingStore = bookingStore;
+        this.slotSupport = slotSupport;
+        this.bookingSupport = bookingSupport;
+        this.clock = clock;
+    }
+
+    @Override
+    public int cancelLinkedBookings(Long passId) {
+        List<Booking> futureBookings = bookingReader.findFuturePassBookings(
+                passId, BookingStatus.BOOKED, LocalDateTime.now(clock));
+
+        futureBookings.forEach(booking -> cancelOne(booking, passId));
+
+        return futureBookings.size();
+    }
+
+    private void cancelOne(Booking booking, Long passId) {
+        booking.cancel();
+
+        Slot slot = slotSupport.releaseSlotCapacity(booking.getSlot().getId());
+
+        bookingSupport.recordHistory(booking, BookingHistoryAction.CANCELED,
+                slot, null, "ADMIN", null);
+
+        bookingStore.save(booking);
+        log.info("Pass환불 연동 취소 [passId={}, bookingId={}]", passId, booking.getId());
+    }
+}

--- a/app/src/main/java/com/personal/happygallery/app/booking/DefaultBookingNoShowService.java
+++ b/app/src/main/java/com/personal/happygallery/app/booking/DefaultBookingNoShowService.java
@@ -1,30 +1,28 @@
-package com.personal.happygallery.app.pass;
+package com.personal.happygallery.app.booking;
 
-import com.personal.happygallery.app.booking.port.out.BookingHistoryPort;
+import com.personal.happygallery.app.booking.port.in.BookingNoShowUseCase;
 import com.personal.happygallery.app.booking.port.out.BookingReaderPort;
 import com.personal.happygallery.app.booking.port.out.BookingStorePort;
-import com.personal.happygallery.domain.error.NotFoundException;
 import com.personal.happygallery.domain.booking.Booking;
-import com.personal.happygallery.domain.booking.BookingHistory;
 import com.personal.happygallery.domain.booking.BookingHistoryAction;
-import com.personal.happygallery.app.pass.port.in.PassNoShowUseCase;
+import com.personal.happygallery.domain.error.NotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
-public class DefaultPassNoShowService implements PassNoShowUseCase {
+class DefaultBookingNoShowService implements BookingNoShowUseCase {
 
     private final BookingReaderPort bookingReader;
     private final BookingStorePort bookingStore;
-    private final BookingHistoryPort bookingHistoryPort;
+    private final BookingSupport bookingSupport;
 
-    public DefaultPassNoShowService(BookingReaderPort bookingReader,
-                                    BookingStorePort bookingStore,
-                                    BookingHistoryPort bookingHistoryPort) {
+    DefaultBookingNoShowService(BookingReaderPort bookingReader,
+                                BookingStorePort bookingStore,
+                                BookingSupport bookingSupport) {
         this.bookingReader = bookingReader;
         this.bookingStore = bookingStore;
-        this.bookingHistoryPort = bookingHistoryPort;
+        this.bookingSupport = bookingSupport;
     }
 
     /**
@@ -35,13 +33,13 @@ public class DefaultPassNoShowService implements PassNoShowUseCase {
      *
      * @param bookingId 결석 처리할 예약 ID
      */
+    @Override
     public Booking markNoShow(Long bookingId) {
         Booking booking = bookingReader.findById(bookingId)
                 .orElseThrow(() -> new NotFoundException("예약"));
 
-        bookingHistoryPort.save(
-                new BookingHistory(booking, BookingHistoryAction.NO_SHOW,
-                        booking.getSlot(), null, "ADMIN", null));
+        bookingSupport.recordHistory(booking, BookingHistoryAction.NO_SHOW,
+                booking.getSlot(), null, "ADMIN", null);
 
         booking.markNoShow();
         return bookingStore.save(booking);

--- a/app/src/main/java/com/personal/happygallery/app/booking/DefaultBookingReminderBatchService.java
+++ b/app/src/main/java/com/personal/happygallery/app/booking/DefaultBookingReminderBatchService.java
@@ -4,16 +4,17 @@ import com.personal.happygallery.app.batch.BatchExecutor;
 import com.personal.happygallery.app.batch.BatchResult;
 import com.personal.happygallery.app.booking.port.in.BookingReminderBatchUseCase;
 import com.personal.happygallery.app.booking.port.out.BookingReaderPort;
-import com.personal.happygallery.app.notification.NotificationService;
 import com.personal.happygallery.domain.booking.Booking;
 import com.personal.happygallery.domain.booking.BookingStatus;
 import com.personal.happygallery.domain.notification.NotificationEventType;
+import com.personal.happygallery.domain.notification.NotificationRequestedEvent;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 /**
@@ -28,14 +29,14 @@ public class DefaultBookingReminderBatchService implements BookingReminderBatchU
     private static final Logger log = LoggerFactory.getLogger(DefaultBookingReminderBatchService.class);
 
     private final BookingReaderPort bookingReaderPort;
-    private final NotificationService notificationService;
+    private final ApplicationEventPublisher eventPublisher;
     private final Clock clock;
 
     public DefaultBookingReminderBatchService(BookingReaderPort bookingReaderPort,
-                                       NotificationService notificationService,
+                                       ApplicationEventPublisher eventPublisher,
                                        Clock clock) {
         this.bookingReaderPort = bookingReaderPort;
-        this.notificationService = notificationService;
+        this.eventPublisher = eventPublisher;
         this.clock = clock;
     }
 
@@ -73,11 +74,11 @@ public class DefaultBookingReminderBatchService implements BookingReminderBatchU
 
     private void sendReminder(Booking booking, NotificationEventType eventType) {
         if (booking.getUserId() != null) {
-            notificationService.notifyByUserId(booking.getUserId(), eventType);
+            eventPublisher.publishEvent(NotificationRequestedEvent.forUser(booking.getUserId(), eventType));
             log.info("리마인드 발송 [bookingId={}, userId={}, type={}]",
                     booking.getId(), booking.getUserId(), eventType);
         } else if (booking.getGuest() != null) {
-            notificationService.notifyByGuestId(booking.getGuest().getId(), eventType);
+            eventPublisher.publishEvent(NotificationRequestedEvent.forGuest(booking.getGuest().getId(), eventType));
             log.info("리마인드 발송 [bookingId={}, guestId={}, type={}]",
                     booking.getId(), booking.getGuest().getId(), eventType);
         } else {

--- a/app/src/main/java/com/personal/happygallery/app/booking/port/in/BookingCancellationPort.java
+++ b/app/src/main/java/com/personal/happygallery/app/booking/port/in/BookingCancellationPort.java
@@ -1,0 +1,18 @@
+package com.personal.happygallery.app.booking.port.in;
+
+/**
+ * Pass 도메인이 연동 예약을 일괄 취소할 때 사용하는 인바운드 포트.
+ *
+ * <p>Pass가 Booking 내부 구현(BookingStorePort, SlotStorePort 등)을
+ * 직접 알지 않아도 연동 예약 취소가 가능하도록 추상화한다.
+ */
+public interface BookingCancellationPort {
+
+    /**
+     * 특정 8회권에 연결된 미래 BOOKED 예약을 모두 취소한다.
+     *
+     * @param passId 8회권 ID
+     * @return 취소된 예약 건수
+     */
+    int cancelLinkedBookings(Long passId);
+}

--- a/app/src/main/java/com/personal/happygallery/app/booking/port/in/BookingNoShowUseCase.java
+++ b/app/src/main/java/com/personal/happygallery/app/booking/port/in/BookingNoShowUseCase.java
@@ -1,13 +1,13 @@
-package com.personal.happygallery.app.pass.port.in;
+package com.personal.happygallery.app.booking.port.in;
 
 import com.personal.happygallery.domain.booking.Booking;
 
 /**
- * 8회권 결석(NO_SHOW) 처리 유스케이스.
+ * 결석(NO_SHOW) 처리 유스케이스.
  *
  * <p>관리자가 수동으로 결석 처리한다.
  */
-public interface PassNoShowUseCase {
+public interface BookingNoShowUseCase {
 
     Booking markNoShow(Long bookingId);
 }

--- a/app/src/main/java/com/personal/happygallery/app/cart/CartCheckoutService.java
+++ b/app/src/main/java/com/personal/happygallery/app/cart/CartCheckoutService.java
@@ -1,5 +1,6 @@
 package com.personal.happygallery.app.cart;
 
+import com.personal.happygallery.app.cart.port.in.CartCheckoutUseCase;
 import com.personal.happygallery.app.cart.port.in.CartUseCase;
 import com.personal.happygallery.app.cart.port.in.CartUseCase.CartItemView;
 import com.personal.happygallery.app.cart.port.in.CartUseCase.CartView;
@@ -12,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
-public class CartCheckoutService {
+public class CartCheckoutService implements CartCheckoutUseCase {
 
     private final CartUseCase cartUseCase;
     private final OrderCreationUseCase orderCreationUseCase;

--- a/app/src/main/java/com/personal/happygallery/app/cart/port/in/CartCheckoutUseCase.java
+++ b/app/src/main/java/com/personal/happygallery/app/cart/port/in/CartCheckoutUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.happygallery.app.cart.port.in;
+
+import com.personal.happygallery.domain.order.Order;
+
+public interface CartCheckoutUseCase {
+
+    Order checkout(Long userId);
+}

--- a/app/src/main/java/com/personal/happygallery/app/inquiry/DefaultInquiryService.java
+++ b/app/src/main/java/com/personal/happygallery/app/inquiry/DefaultInquiryService.java
@@ -80,6 +80,17 @@ public class DefaultInquiryService implements InquiryUseCase {
         return inquiryStore.save(inquiry);
     }
 
+    @Transactional
+    public InquiryWithUser replyAndGet(Long inquiryId, String replyContent, Long adminId) {
+        Inquiry inquiry = inquiryReader.findById(inquiryId)
+                .orElseThrow(() -> new NotFoundException("문의"));
+        inquiry.reply(replyContent, adminId, LocalDateTime.now(clock));
+        inquiry = inquiryStore.save(inquiry);
+        String name = userReader.findById(inquiry.getUserId())
+                .map(User::getName).orElse("탈퇴회원");
+        return new InquiryWithUser(inquiry, name);
+    }
+
     private Map<Long, User> batchFetchUsers(List<Inquiry> inquiries) {
         List<Long> userIds = inquiries.stream().map(Inquiry::getUserId).distinct().toList();
         return userReader.findAllById(userIds).stream()

--- a/app/src/main/java/com/personal/happygallery/app/inquiry/port/in/InquiryUseCase.java
+++ b/app/src/main/java/com/personal/happygallery/app/inquiry/port/in/InquiryUseCase.java
@@ -23,4 +23,6 @@ public interface InquiryUseCase {
     InquiryWithUser findByIdForAdmin(Long inquiryId);
 
     Inquiry reply(Long inquiryId, String replyContent, Long adminId);
+
+    InquiryWithUser replyAndGet(Long inquiryId, String replyContent, Long adminId);
 }

--- a/app/src/main/java/com/personal/happygallery/app/notification/NotificationEventListener.java
+++ b/app/src/main/java/com/personal/happygallery/app/notification/NotificationEventListener.java
@@ -1,0 +1,29 @@
+package com.personal.happygallery.app.notification;
+
+import com.personal.happygallery.domain.notification.NotificationRequestedEvent;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+class NotificationEventListener {
+
+    private final NotificationService notificationService;
+
+    NotificationEventListener(NotificationService notificationService) {
+        this.notificationService = notificationService;
+    }
+
+    @Async("notificationExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    public void handle(NotificationRequestedEvent event) {
+        if (event.guestId() != null && event.phone() != null) {
+            notificationService.sendToGuest(event.guestId(), event.phone(), event.name(), event.eventType());
+        } else if (event.guestId() != null) {
+            notificationService.sendByGuestId(event.guestId(), event.eventType());
+        } else if (event.userId() != null) {
+            notificationService.sendByUserId(event.userId(), event.eventType());
+        }
+    }
+}

--- a/app/src/main/java/com/personal/happygallery/app/notification/NotificationService.java
+++ b/app/src/main/java/com/personal/happygallery/app/notification/NotificationService.java
@@ -55,11 +55,55 @@ public class NotificationService {
      * <p>{@code @Order} 우선순위 순으로 시도한다. 한 채널이 성공하면 이후 채널은 시도하지 않는다.
      * 모든 채널 실패 시에도 예외를 던지지 않고 로그만 기록한다.
      *
-     * <p>비동기로 실행되므로 호출자의 트랜잭션과 독립적이다.
+     * @deprecated 이벤트 기반 전환 중. 새 코드는 {@code ApplicationEventPublisher}를 사용한다.
      */
+    @Deprecated
     @Async("notificationExecutor")
     public void notifyGuest(Long guestId, String phone, String name,
                             NotificationEventType eventType) {
+        sendToGuest(guestId, phone, name, eventType);
+    }
+
+    /**
+     * guestId 만으로 게스트에게 알림을 발송한다.
+     * 게스트가 존재하지 않으면 경고 로그를 남기고 무시한다.
+     *
+     * @deprecated 이벤트 기반 전환 중. 새 코드는 {@code ApplicationEventPublisher}를 사용한다.
+     */
+    @Deprecated
+    @Async("notificationExecutor")
+    public void notifyByGuestId(Long guestId, NotificationEventType eventType) {
+        sendByGuestId(guestId, eventType);
+    }
+
+    /**
+     * userId 만으로 회원에게 알림을 발송한다.
+     * 회원이 존재하지 않으면 경고 로그를 남기고 무시한다.
+     *
+     * @deprecated 이벤트 기반 전환 중. 새 코드는 {@code ApplicationEventPublisher}를 사용한다.
+     */
+    @Deprecated
+    @Async("notificationExecutor")
+    public void notifyByUserId(Long userId, NotificationEventType eventType) {
+        sendByUserId(userId, eventType);
+    }
+
+    /**
+     * 회원에게 알림을 발송한다. phone / name 을 이미 알고 있을 때 사용한다.
+     *
+     * @deprecated 이벤트 기반 전환 중. 새 코드는 {@code ApplicationEventPublisher}를 사용한다.
+     */
+    @Deprecated
+    @Async("notificationExecutor")
+    public void notifyUser(Long userId, String phone, String name,
+                           NotificationEventType eventType) {
+        sendToUser(userId, phone, name, eventType);
+    }
+
+    // -- 이벤트 리스너용 package-private 메서드 (@Async 없음) --
+
+    void sendToGuest(Long guestId, String phone, String name,
+                     NotificationEventType eventType) {
         LocalDateTime sentAt = LocalDateTime.now(clock);
         for (NotificationSenderPort sender : senders) {
             try {
@@ -77,44 +121,28 @@ public class NotificationService {
         log.error("[알림] 모든 채널 실패 [guestId={} event={}]", guestId, eventType);
     }
 
-    /**
-     * guestId 만으로 게스트에게 알림을 발송한다.
-     * 게스트가 존재하지 않으면 경고 로그를 남기고 무시한다.
-     *
-     * <p>비동기로 실행되므로 호출자의 트랜잭션과 독립적이다.
-     */
-    @Async("notificationExecutor")
-    public void notifyByGuestId(Long guestId, NotificationEventType eventType) {
+    void sendByGuestId(Long guestId, NotificationEventType eventType) {
         if (guestId == null) {
             return;
         }
         guestReader.findById(guestId).ifPresentOrElse(
-                guest -> notifyGuest(guest.getId(), guest.getPhone(), guest.getName(), eventType),
+                guest -> sendToGuest(guest.getId(), guest.getPhone(), guest.getName(), eventType),
                 () -> log.warn("[알림] 게스트 미존재 [guestId={}]", guestId)
         );
     }
 
-    /**
-     * userId 만으로 회원에게 알림을 발송한다.
-     * 회원이 존재하지 않으면 경고 로그를 남기고 무시한다.
-     */
-    @Async("notificationExecutor")
-    public void notifyByUserId(Long userId, NotificationEventType eventType) {
+    void sendByUserId(Long userId, NotificationEventType eventType) {
         if (userId == null) {
             return;
         }
         userReader.findById(userId).ifPresentOrElse(
-                user -> notifyUser(userId, user.getPhone(), user.getName(), eventType),
+                user -> sendToUser(userId, user.getPhone(), user.getName(), eventType),
                 () -> log.warn("[알림] 회원 미존재 [userId={}]", userId)
         );
     }
 
-    /**
-     * 회원에게 알림을 발송한다. phone / name 을 이미 알고 있을 때 사용한다.
-     */
-    @Async("notificationExecutor")
-    public void notifyUser(Long userId, String phone, String name,
-                           NotificationEventType eventType) {
+    void sendToUser(Long userId, String phone, String name,
+                    NotificationEventType eventType) {
         LocalDateTime sentAt = LocalDateTime.now(clock);
         for (NotificationSenderPort sender : senders) {
             try {

--- a/app/src/main/java/com/personal/happygallery/app/order/DefaultPickupDeadlineReminderBatchService.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/DefaultPickupDeadlineReminderBatchService.java
@@ -2,12 +2,12 @@ package com.personal.happygallery.app.order;
 
 import com.personal.happygallery.app.batch.BatchExecutor;
 import com.personal.happygallery.app.batch.BatchResult;
-import com.personal.happygallery.app.notification.NotificationService;
 import com.personal.happygallery.app.notification.port.out.NotificationLogReaderPort;
 import com.personal.happygallery.app.order.port.in.PickupDeadlineReminderBatchUseCase;
 import com.personal.happygallery.app.order.port.out.FulfillmentPort;
 import com.personal.happygallery.app.order.port.out.OrderReaderPort;
 import com.personal.happygallery.domain.notification.NotificationEventType;
+import com.personal.happygallery.domain.notification.NotificationRequestedEvent;
 import com.personal.happygallery.domain.order.Fulfillment;
 import com.personal.happygallery.domain.order.Order;
 import java.time.Clock;
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 /**
@@ -30,18 +31,18 @@ public class DefaultPickupDeadlineReminderBatchService implements PickupDeadline
 
     private final FulfillmentPort fulfillmentPort;
     private final OrderReaderPort orderReaderPort;
-    private final NotificationService notificationService;
+    private final ApplicationEventPublisher eventPublisher;
     private final NotificationLogReaderPort notificationLogReader;
     private final Clock clock;
 
     public DefaultPickupDeadlineReminderBatchService(FulfillmentPort fulfillmentPort,
                                                       OrderReaderPort orderReaderPort,
-                                                      NotificationService notificationService,
+                                                      ApplicationEventPublisher eventPublisher,
                                                       NotificationLogReaderPort notificationLogReader,
                                                       Clock clock) {
         this.fulfillmentPort = fulfillmentPort;
         this.orderReaderPort = orderReaderPort;
-        this.notificationService = notificationService;
+        this.eventPublisher = eventPublisher;
         this.notificationLogReader = notificationLogReader;
         this.clock = clock;
     }
@@ -72,14 +73,14 @@ public class DefaultPickupDeadlineReminderBatchService implements PickupDeadline
                 log.info("픽업 마감 알림 중복 스킵 [orderId={} userId={}]", orderId, order.getUserId());
                 return false;
             }
-            notificationService.notifyByUserId(order.getUserId(), eventType);
+            eventPublisher.publishEvent(NotificationRequestedEvent.forUser(order.getUserId(), eventType));
         } else if (order.getGuestId() != null) {
             if (notificationLogReader.existsSentNotification(
                     order.getGuestId(), eventType, deduplicationStart, now)) {
                 log.info("픽업 마감 알림 중복 스킵 [orderId={} guestId={}]", orderId, order.getGuestId());
                 return false;
             }
-            notificationService.notifyByGuestId(order.getGuestId(), eventType);
+            eventPublisher.publishEvent(NotificationRequestedEvent.forGuest(order.getGuestId(), eventType));
         } else {
             log.warn("픽업 마감 알림 대상 없음 [orderId={}]", orderId);
             return false;

--- a/app/src/main/java/com/personal/happygallery/app/order/OrderRefundSupport.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/OrderRefundSupport.java
@@ -1,15 +1,16 @@
 package com.personal.happygallery.app.order;
 
-import com.personal.happygallery.app.notification.NotificationService;
 import com.personal.happygallery.app.order.port.out.OrderItemPort;
 import com.personal.happygallery.app.payment.RefundExecutionService;
 import com.personal.happygallery.app.product.InventoryService;
 import com.personal.happygallery.domain.booking.Refund;
 import com.personal.happygallery.domain.notification.NotificationEventType;
+import com.personal.happygallery.domain.notification.NotificationRequestedEvent;
 import com.personal.happygallery.domain.order.Order;
 import com.personal.happygallery.domain.order.OrderItem;
 import com.personal.happygallery.domain.payment.RefundStatus;
 import java.util.List;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,16 +27,16 @@ class OrderRefundSupport {
     private final OrderItemPort orderItemPort;
     private final InventoryService inventoryService;
     private final RefundExecutionService refundExecutionService;
-    private final NotificationService notificationService;
+    private final ApplicationEventPublisher eventPublisher;
 
     OrderRefundSupport(OrderItemPort orderItemPort,
                        InventoryService inventoryService,
                        RefundExecutionService refundExecutionService,
-                       NotificationService notificationService) {
+                       ApplicationEventPublisher eventPublisher) {
         this.orderItemPort = orderItemPort;
         this.inventoryService = inventoryService;
         this.refundExecutionService = refundExecutionService;
-        this.notificationService = notificationService;
+        this.eventPublisher = eventPublisher;
     }
 
     /**
@@ -52,7 +53,7 @@ class OrderRefundSupport {
 
         Refund refund = refundExecutionService.processOrderRefund(order.getId(), order.getTotalAmount());
         if (refund.getStatus() == RefundStatus.SUCCEEDED) {
-            notificationService.notifyByGuestId(order.getGuestId(), NotificationEventType.ORDER_REFUNDED);
+            eventPublisher.publishEvent(NotificationRequestedEvent.forGuest(order.getGuestId(), NotificationEventType.ORDER_REFUNDED));
         }
     }
 }

--- a/app/src/main/java/com/personal/happygallery/app/order/OrderService.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/OrderService.java
@@ -1,9 +1,9 @@
 package com.personal.happygallery.app.order;
 
-import com.personal.happygallery.app.notification.NotificationService;
 import com.personal.happygallery.app.order.port.out.OrderItemPort;
 import com.personal.happygallery.app.order.port.out.OrderStorePort;
 import com.personal.happygallery.domain.notification.NotificationEventType;
+import com.personal.happygallery.domain.notification.NotificationRequestedEvent;
 import com.personal.happygallery.domain.order.Order;
 import com.personal.happygallery.domain.order.OrderItem;
 import com.personal.happygallery.app.product.InventoryService;
@@ -11,6 +11,7 @@ import com.personal.happygallery.app.token.GuestTokenService;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,20 +28,20 @@ public class OrderService {
     private final OrderStorePort orderStore;
     private final OrderItemPort orderItemPort;
     private final InventoryService inventoryService;
-    private final NotificationService notificationService;
+    private final ApplicationEventPublisher eventPublisher;
     private final GuestTokenService guestTokenService;
     private final Clock clock;
 
     public OrderService(OrderStorePort orderStore,
                         OrderItemPort orderItemPort,
                         InventoryService inventoryService,
-                        NotificationService notificationService,
+                        ApplicationEventPublisher eventPublisher,
                         GuestTokenService guestTokenService,
                         Clock clock) {
         this.orderStore = orderStore;
         this.orderItemPort = orderItemPort;
         this.inventoryService = inventoryService;
-        this.notificationService = notificationService;
+        this.eventPublisher = eventPublisher;
         this.guestTokenService = guestTokenService;
         this.clock = clock;
     }
@@ -75,7 +76,7 @@ public class OrderService {
             inventoryService.deduct(item.productId(), item.qty());
         }
 
-        notificationService.notifyByGuestId(guestId, NotificationEventType.ORDER_PAID);
+        eventPublisher.publishEvent(NotificationRequestedEvent.forGuest(guestId, NotificationEventType.ORDER_PAID));
 
         return new OrderCreationResult(order, rawToken);
     }

--- a/app/src/main/java/com/personal/happygallery/app/pass/DefaultPassCreditService.java
+++ b/app/src/main/java/com/personal/happygallery/app/pass/DefaultPassCreditService.java
@@ -1,0 +1,63 @@
+package com.personal.happygallery.app.pass;
+
+import com.personal.happygallery.app.pass.port.in.PassCreditPort;
+import com.personal.happygallery.app.pass.port.out.PassLedgerStorePort;
+import com.personal.happygallery.app.pass.port.out.PassPurchaseReaderPort;
+import com.personal.happygallery.app.pass.port.out.PassPurchaseStorePort;
+import com.personal.happygallery.domain.error.NotFoundException;
+import com.personal.happygallery.domain.pass.PassLedger;
+import com.personal.happygallery.domain.pass.PassLedgerType;
+import com.personal.happygallery.domain.pass.PassPurchase;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+class DefaultPassCreditService implements PassCreditPort {
+
+    private final PassPurchaseReaderPort passPurchaseReader;
+    private final PassPurchaseStorePort passPurchaseStore;
+    private final PassLedgerStorePort passLedgerStore;
+    private final Clock clock;
+
+    DefaultPassCreditService(PassPurchaseReaderPort passPurchaseReader,
+                             PassPurchaseStorePort passPurchaseStore,
+                             PassLedgerStorePort passLedgerStore,
+                             Clock clock) {
+        this.passPurchaseReader = passPurchaseReader;
+        this.passPurchaseStore = passPurchaseStore;
+        this.passLedgerStore = passLedgerStore;
+        this.clock = clock;
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.MANDATORY)
+    public PassPurchase deductCredit(Long passId, Long ownerUserId) {
+        PassPurchase pass = passPurchaseReader.findById(passId)
+                .orElseThrow(() -> new NotFoundException("8회권"));
+
+        if (ownerUserId != null && !Objects.equals(pass.getUserId(), ownerUserId)) {
+            throw new NotFoundException("8회권");
+        }
+
+        pass.requireUsable(LocalDateTime.now(clock));
+        passLedgerStore.save(new PassLedger(pass, PassLedgerType.USE, 1));
+        pass.useCredit();
+        passPurchaseStore.save(pass);
+        return pass;
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void restoreCredit(Long passId, Long bookingId) {
+        PassPurchase pass = passPurchaseReader.findById(passId)
+                .orElseThrow(() -> new NotFoundException("8회권"));
+        passLedgerStore.save(
+                new PassLedger(pass, PassLedgerType.REFUND, 1, bookingId));
+        pass.refundCredit();
+        passPurchaseStore.save(pass);
+    }
+}

--- a/app/src/main/java/com/personal/happygallery/app/pass/DefaultPassExpiryBatchService.java
+++ b/app/src/main/java/com/personal/happygallery/app/pass/DefaultPassExpiryBatchService.java
@@ -3,14 +3,15 @@ package com.personal.happygallery.app.pass;
 import com.personal.happygallery.app.batch.BatchExecutor;
 import com.personal.happygallery.app.pass.port.in.PassExpiryBatchUseCase;
 import com.personal.happygallery.app.batch.BatchResult;
-import com.personal.happygallery.app.notification.NotificationService;
 import com.personal.happygallery.app.notification.port.out.NotificationLogReaderPort;
 import com.personal.happygallery.app.pass.port.out.PassPurchaseReaderPort;
 import com.personal.happygallery.domain.notification.NotificationEventType;
+import com.personal.happygallery.domain.notification.NotificationRequestedEvent;
 import com.personal.happygallery.domain.pass.PassPurchase;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,18 +23,18 @@ public class DefaultPassExpiryBatchService implements PassExpiryBatchUseCase {
     private final PassPurchaseReaderPort passPurchaseReader;
     private final PassExpireProcessor passExpireProcessor;
     private final NotificationLogReaderPort notificationLogReader;
-    private final NotificationService notificationService;
+    private final ApplicationEventPublisher eventPublisher;
     private final Clock clock;
 
     public DefaultPassExpiryBatchService(PassPurchaseReaderPort passPurchaseReader,
                                   PassExpireProcessor passExpireProcessor,
                                   NotificationLogReaderPort notificationLogReader,
-                                  NotificationService notificationService,
+                                  ApplicationEventPublisher eventPublisher,
                                   Clock clock) {
         this.passPurchaseReader = passPurchaseReader;
         this.passExpireProcessor = passExpireProcessor;
         this.notificationLogReader = notificationLogReader;
-        this.notificationService = notificationService;
+        this.eventPublisher = eventPublisher;
         this.clock = clock;
     }
 
@@ -99,7 +100,7 @@ public class DefaultPassExpiryBatchService implements PassExpiryBatchUseCase {
                             sentEnd)) {
                         return false;
                     }
-                    notificationService.notifyByUserId(pass.getUserId(), NotificationEventType.PASS_EXPIRY_SOON);
+                    eventPublisher.publishEvent(NotificationRequestedEvent.forUser(pass.getUserId(), NotificationEventType.PASS_EXPIRY_SOON));
                     return true;
                 },
                 "8회권 만료 알림");

--- a/app/src/main/java/com/personal/happygallery/app/pass/DefaultPassRefundService.java
+++ b/app/src/main/java/com/personal/happygallery/app/pass/DefaultPassRefundService.java
@@ -1,27 +1,16 @@
 package com.personal.happygallery.app.pass;
 
-import com.personal.happygallery.app.booking.port.out.BookingHistoryPort;
-import com.personal.happygallery.app.booking.port.out.BookingReaderPort;
-import com.personal.happygallery.app.booking.port.out.BookingStorePort;
-import com.personal.happygallery.app.booking.port.out.SlotReaderPort;
-import com.personal.happygallery.app.booking.port.out.SlotStorePort;
+import com.personal.happygallery.app.booking.port.in.BookingCancellationPort;
+import com.personal.happygallery.app.pass.port.in.PassRefundUseCase;
 import com.personal.happygallery.app.pass.port.out.PassLedgerStorePort;
 import com.personal.happygallery.app.pass.port.out.PassPurchaseReaderPort;
 import com.personal.happygallery.app.pass.port.out.PassPurchaseStorePort;
 import com.personal.happygallery.domain.error.NotFoundException;
-import com.personal.happygallery.domain.booking.Booking;
-import com.personal.happygallery.domain.booking.BookingHistory;
-import com.personal.happygallery.domain.booking.BookingHistoryAction;
-import com.personal.happygallery.domain.booking.BookingStatus;
 import com.personal.happygallery.domain.pass.PassLedger;
 import com.personal.happygallery.domain.pass.PassLedgerType;
 import com.personal.happygallery.domain.pass.PassPurchase;
-import java.time.Clock;
-import java.time.LocalDateTime;
-import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.personal.happygallery.app.pass.port.in.PassRefundUseCase;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,31 +23,16 @@ public class DefaultPassRefundService implements PassRefundUseCase {
     private final PassPurchaseReaderPort passPurchaseReader;
     private final PassPurchaseStorePort passPurchaseStore;
     private final PassLedgerStorePort passLedgerStore;
-    private final BookingReaderPort bookingReader;
-    private final BookingStorePort bookingStore;
-    private final BookingHistoryPort bookingHistoryPort;
-    private final SlotReaderPort slotReader;
-    private final SlotStorePort slotStore;
-    private final Clock clock;
+    private final BookingCancellationPort bookingCancellationPort;
 
     public DefaultPassRefundService(PassPurchaseReaderPort passPurchaseReader,
                              PassPurchaseStorePort passPurchaseStore,
                              PassLedgerStorePort passLedgerStore,
-                             BookingReaderPort bookingReader,
-                             BookingStorePort bookingStore,
-                             BookingHistoryPort bookingHistoryPort,
-                             SlotReaderPort slotReader,
-                             SlotStorePort slotStore,
-                             Clock clock) {
+                             BookingCancellationPort bookingCancellationPort) {
         this.passPurchaseReader = passPurchaseReader;
         this.passPurchaseStore = passPurchaseStore;
         this.passLedgerStore = passLedgerStore;
-        this.bookingReader = bookingReader;
-        this.bookingStore = bookingStore;
-        this.bookingHistoryPort = bookingHistoryPort;
-        this.slotReader = slotReader;
-        this.slotStore = slotStore;
-        this.clock = clock;
+        this.bookingCancellationPort = bookingCancellationPort;
     }
 
     /**
@@ -79,10 +53,7 @@ public class DefaultPassRefundService implements PassRefundUseCase {
                 .orElseThrow(() -> new NotFoundException("8회권"));
 
         // 1. 미래 BOOKED 예약 자동 취소
-        List<Booking> futureBookings = bookingReader.findFuturePassBookings(
-                passId, BookingStatus.BOOKED, LocalDateTime.now(clock));
-
-        futureBookings.forEach(booking -> cancelLinkedBooking(booking, passId));
+        int cancelledCount = bookingCancellationPort.cancelLinkedBookings(passId);
 
         // 2. REFUND ledger 기록 (잔여 크레딧 전체)
         int refundCredits = pass.getRemainingCredits();
@@ -97,23 +68,8 @@ public class DefaultPassRefundService implements PassRefundUseCase {
         passPurchaseStore.save(pass);
 
         log.info("Pass환불 완료 [passId={}] 취소예약={}건, 환불크레딧={}, 환불금액={}",
-                passId, futureBookings.size(), refundCredits, refundAmount);
+                passId, cancelledCount, refundCredits, refundAmount);
 
-        return new PassRefundResult(futureBookings.size(), refundCredits, refundAmount);
-    }
-
-    private void cancelLinkedBooking(Booking booking, Long passId) {
-        var slot = slotReader.findByIdWithLock(booking.getSlot().getId())
-                .orElseThrow(() -> new NotFoundException("슬롯"));
-        slot.decrementBookedCount();
-        slotStore.save(slot);
-
-        bookingHistoryPort.save(
-                new BookingHistory(booking, BookingHistoryAction.CANCELED,
-                        slot, null, "ADMIN", null));
-
-        booking.cancel();
-        bookingStore.save(booking);
-        log.info("Pass환불 연동 취소 [passId={}, bookingId={}]", passId, booking.getId());
+        return new PassRefundResult(cancelledCount, refundCredits, refundAmount);
     }
 }

--- a/app/src/main/java/com/personal/happygallery/app/pass/port/in/PassCreditPort.java
+++ b/app/src/main/java/com/personal/happygallery/app/pass/port/in/PassCreditPort.java
@@ -1,0 +1,29 @@
+package com.personal.happygallery.app.pass.port.in;
+
+import com.personal.happygallery.domain.pass.PassPurchase;
+
+/**
+ * Booking 도메인이 Pass 크레딧을 차감/복구할 때 사용하는 인바운드 포트.
+ *
+ * <p>Booking이 Pass 내부 구현(PassLedger, PassPurchaseStorePort)을
+ * 직접 알지 않아도 크레딧 조작이 가능하도록 추상화한다.
+ */
+public interface PassCreditPort {
+
+    /**
+     * 8회권 크레딧 1회 차감.
+     *
+     * @param passId      8회권 ID
+     * @param ownerUserId 소유자 회원 ID (회원 예약 시 non-null, 게스트 예약 시 null)
+     * @return 차감된 PassPurchase
+     */
+    PassPurchase deductCredit(Long passId, Long ownerUserId);
+
+    /**
+     * 예약 취소 시 8회권 크레딧 1회 복구.
+     *
+     * @param passId    8회권 ID
+     * @param bookingId 복구 사유가 된 예약 ID
+     */
+    void restoreCredit(Long passId, Long bookingId);
+}

--- a/app/src/main/java/com/personal/happygallery/app/payment/RefundExecutionService.java
+++ b/app/src/main/java/com/personal/happygallery/app/payment/RefundExecutionService.java
@@ -1,10 +1,8 @@
 package com.personal.happygallery.app.payment;
 
-import com.personal.happygallery.app.booking.port.out.BookingReaderPort;
 import com.personal.happygallery.app.payment.port.out.PaymentPort;
 import com.personal.happygallery.app.payment.port.out.RefundPort;
 import com.personal.happygallery.app.payment.port.out.RefundResult;
-import com.personal.happygallery.domain.error.NotFoundException;
 import com.personal.happygallery.domain.booking.Booking;
 import com.personal.happygallery.domain.booking.Refund;
 import org.slf4j.Logger;
@@ -25,14 +23,11 @@ public class RefundExecutionService {
     private static final Logger log = LoggerFactory.getLogger(RefundExecutionService.class);
 
     private final RefundPort refundPort;
-    private final BookingReaderPort bookingReaderPort;
     private final PaymentPort paymentPort;
 
     public RefundExecutionService(RefundPort refundPort,
-                                  BookingReaderPort bookingReaderPort,
                                   PaymentPort paymentPort) {
         this.refundPort = refundPort;
-        this.bookingReaderPort = bookingReaderPort;
         this.paymentPort = paymentPort;
     }
 
@@ -43,11 +38,9 @@ public class RefundExecutionService {
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public Refund processBookingRefund(Long bookingId, long amount) {
-        Booking booking = bookingReaderPort.findById(bookingId)
-                .orElseThrow(() -> new NotFoundException("예약"));
+    public Refund processBookingRefund(Booking booking, long amount) {
         Refund refund = refundPort.save(Refund.forBooking(booking, amount));
-        return executeRefund(refund, "bookingId=" + bookingId);
+        return executeRefund(refund, "bookingId=" + booking.getId());
     }
 
     public Refund executeRefund(Refund refund, String target) {

--- a/app/src/main/java/com/personal/happygallery/app/qna/DefaultProductQnaService.java
+++ b/app/src/main/java/com/personal/happygallery/app/qna/DefaultProductQnaService.java
@@ -95,6 +95,17 @@ public class DefaultProductQnaService implements ProductQnaUseCase {
         return qnaStore.save(qna);
     }
 
+    @Transactional
+    public QnaWithAuthor replyAndGet(Long qnaId, String replyContent, Long adminId) {
+        ProductQna qna = qnaReader.findById(qnaId)
+                .orElseThrow(() -> new NotFoundException("Q&A"));
+        qna.reply(replyContent, adminId, LocalDateTime.now(clock));
+        qna = qnaStore.save(qna);
+        String authorName = userReader.findById(qna.getUserId())
+                .map(User::getName).orElse("탈퇴회원");
+        return new QnaWithAuthor(qna, authorName);
+    }
+
     private Map<Long, User> batchFetchUsers(List<ProductQna> qnaList) {
         List<Long> userIds = qnaList.stream().map(ProductQna::getUserId).distinct().toList();
         return userReader.findAllById(userIds).stream()

--- a/app/src/main/java/com/personal/happygallery/app/qna/port/in/ProductQnaUseCase.java
+++ b/app/src/main/java/com/personal/happygallery/app/qna/port/in/ProductQnaUseCase.java
@@ -20,4 +20,6 @@ public interface ProductQnaUseCase {
     QnaWithAuthor verifyAndGet(Long qnaId, String rawPassword);
 
     ProductQna reply(Long qnaId, String replyContent, Long adminId);
+
+    QnaWithAuthor replyAndGet(Long qnaId, String replyContent, Long adminId);
 }

--- a/app/src/main/java/com/personal/happygallery/app/web/admin/AdminBookingController.java
+++ b/app/src/main/java/com/personal/happygallery/app/web/admin/AdminBookingController.java
@@ -1,7 +1,7 @@
 package com.personal.happygallery.app.web.admin;
 
 import com.personal.happygallery.app.booking.port.in.AdminBookingQueryUseCase;
-import com.personal.happygallery.app.pass.port.in.PassNoShowUseCase;
+import com.personal.happygallery.app.booking.port.in.BookingNoShowUseCase;
 import com.personal.happygallery.app.search.dto.AdminBookingSearchRow;
 import com.personal.happygallery.app.search.port.in.AdminBookingSearchUseCase;
 import com.personal.happygallery.app.web.OffsetPage;
@@ -25,14 +25,14 @@ public class AdminBookingController {
 
     private final AdminBookingQueryUseCase adminBookingQueryUseCase;
     private final AdminBookingSearchUseCase adminBookingSearchUseCase;
-    private final PassNoShowUseCase passNoShowUseCase;
+    private final BookingNoShowUseCase bookingNoShowUseCase;
 
     public AdminBookingController(AdminBookingQueryUseCase adminBookingQueryUseCase,
                                   AdminBookingSearchUseCase adminBookingSearchUseCase,
-                                  PassNoShowUseCase passNoShowUseCase) {
+                                  BookingNoShowUseCase bookingNoShowUseCase) {
         this.adminBookingQueryUseCase = adminBookingQueryUseCase;
         this.adminBookingSearchUseCase = adminBookingSearchUseCase;
-        this.passNoShowUseCase = passNoShowUseCase;
+        this.bookingNoShowUseCase = bookingNoShowUseCase;
     }
 
     /** GET /admin/bookings?date=2026-03-08&status=BOOKED — 날짜별 예약 조회 (상태 필터 선택) */
@@ -58,7 +58,7 @@ public class AdminBookingController {
     /** 결석 처리 — 8회권 크레딧 소멸 유지, 상태 NO_SHOW 전이 */
     @PostMapping("/{bookingId}/no-show")
     public BookingNoShowResponse markNoShow(@PathVariable Long bookingId) {
-        Booking booking = passNoShowUseCase.markNoShow(bookingId);
+        Booking booking = bookingNoShowUseCase.markNoShow(bookingId);
         return BookingNoShowResponse.from(booking);
     }
 }

--- a/app/src/main/java/com/personal/happygallery/app/web/admin/AdminInquiryController.java
+++ b/app/src/main/java/com/personal/happygallery/app/web/admin/AdminInquiryController.java
@@ -5,7 +5,6 @@ import com.personal.happygallery.app.inquiry.port.in.InquiryUseCase.InquiryWithU
 import com.personal.happygallery.app.web.AdminAuthFilter;
 import com.personal.happygallery.app.web.admin.dto.AdminInquiryResponse;
 import com.personal.happygallery.app.web.admin.dto.InquiryReplyRequest;
-import com.personal.happygallery.domain.inquiry.Inquiry;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -44,8 +43,6 @@ public class AdminInquiryController {
                                       @RequestBody @Valid InquiryReplyRequest request,
                                       HttpServletRequest httpRequest) {
         Long adminId = (Long) httpRequest.getAttribute(AdminAuthFilter.ADMIN_USER_ID_ATTR);
-        Inquiry inquiry = inquiryUseCase.reply(id, request.replyContent(), adminId);
-        String userName = inquiryUseCase.findByIdForAdmin(id).userName();
-        return AdminInquiryResponse.from(new InquiryWithUser(inquiry, userName));
+        return AdminInquiryResponse.from(inquiryUseCase.replyAndGet(id, request.replyContent(), adminId));
     }
 }

--- a/app/src/main/java/com/personal/happygallery/app/web/admin/AdminProductQnaController.java
+++ b/app/src/main/java/com/personal/happygallery/app/web/admin/AdminProductQnaController.java
@@ -5,7 +5,6 @@ import com.personal.happygallery.app.qna.port.in.ProductQnaUseCase.QnaWithAuthor
 import com.personal.happygallery.app.web.AdminAuthFilter;
 import com.personal.happygallery.app.web.admin.dto.AdminQnaResponse;
 import com.personal.happygallery.app.web.admin.dto.QnaReplyRequest;
-import com.personal.happygallery.domain.qna.ProductQna;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -39,11 +38,6 @@ public class AdminProductQnaController {
                                   @RequestBody @Valid QnaReplyRequest request,
                                   HttpServletRequest httpRequest) {
         Long adminId = (Long) httpRequest.getAttribute(AdminAuthFilter.ADMIN_USER_ID_ATTR);
-        ProductQna qna = qnaUseCase.reply(id, request.replyContent(), adminId);
-        String authorName = qnaUseCase.listByProduct(qna.getProductId()).stream()
-                .filter(q -> q.qna().getId().equals(qna.getId()))
-                .map(QnaWithAuthor::authorName)
-                .findFirst().orElse("탈퇴회원");
-        return AdminQnaResponse.from(new QnaWithAuthor(qna, authorName));
+        return AdminQnaResponse.from(qnaUseCase.replyAndGet(id, request.replyContent(), adminId));
     }
 }

--- a/app/src/main/java/com/personal/happygallery/app/web/customer/MeCartController.java
+++ b/app/src/main/java/com/personal/happygallery/app/web/customer/MeCartController.java
@@ -1,6 +1,6 @@
 package com.personal.happygallery.app.web.customer;
 
-import com.personal.happygallery.app.cart.CartCheckoutService;
+import com.personal.happygallery.app.cart.port.in.CartCheckoutUseCase;
 import com.personal.happygallery.app.cart.port.in.CartUseCase;
 import com.personal.happygallery.app.cart.port.in.CartUseCase.CartView;
 import com.personal.happygallery.app.web.CustomerAuthFilter;
@@ -27,11 +27,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class MeCartController {
 
     private final CartUseCase cartUseCase;
-    private final CartCheckoutService cartCheckoutService;
+    private final CartCheckoutUseCase cartCheckoutUseCase;
 
-    public MeCartController(CartUseCase cartUseCase, CartCheckoutService cartCheckoutService) {
+    public MeCartController(CartUseCase cartUseCase, CartCheckoutUseCase cartCheckoutUseCase) {
         this.cartUseCase = cartUseCase;
-        this.cartCheckoutService = cartCheckoutService;
+        this.cartCheckoutUseCase = cartCheckoutUseCase;
     }
 
     @GetMapping
@@ -62,7 +62,7 @@ public class MeCartController {
     @PostMapping("/checkout")
     @ResponseStatus(HttpStatus.CREATED)
     public MyOrderSummary checkout(HttpServletRequest request) {
-        Order order = cartCheckoutService.checkout(getUserId(request));
+        Order order = cartCheckoutUseCase.checkout(getUserId(request));
         return MyOrderSummary.from(order);
     }
 

--- a/domain/src/main/java/com/personal/happygallery/domain/notification/NotificationRequestedEvent.java
+++ b/domain/src/main/java/com/personal/happygallery/domain/notification/NotificationRequestedEvent.java
@@ -1,0 +1,30 @@
+package com.personal.happygallery.domain.notification;
+
+/**
+ * 알림 발송 요청 이벤트.
+ *
+ * <p>guestId/userId 중 하나만 non-null이어야 한다.
+ * phone/name이 non-null이면 조회 없이 바로 발송하고,
+ * null이면 guestId/userId로 수신자 정보를 조회한 뒤 발송한다.
+ */
+public record NotificationRequestedEvent(
+        Long guestId,
+        Long userId,
+        String phone,
+        String name,
+        NotificationEventType eventType
+) {
+
+    public static NotificationRequestedEvent forGuest(Long guestId, NotificationEventType eventType) {
+        return new NotificationRequestedEvent(guestId, null, null, null, eventType);
+    }
+
+    public static NotificationRequestedEvent forGuestWithContact(Long guestId, String phone, String name,
+                                                                  NotificationEventType eventType) {
+        return new NotificationRequestedEvent(guestId, null, phone, name, eventType);
+    }
+
+    public static NotificationRequestedEvent forUser(Long userId, NotificationEventType eventType) {
+        return new NotificationRequestedEvent(null, userId, null, null, eventType);
+    }
+}

--- a/infra/src/main/java/com/personal/happygallery/infra/cart/CartItemRepository.java
+++ b/infra/src/main/java/com/personal/happygallery/infra/cart/CartItemRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CartItemRepository extends JpaRepository<CartItem, Long>,
-        CartItemStorePort, CartItemReaderPort {
+        CartItemReaderPort, CartItemStorePort {
 
     @Override
     List<CartItem> findByUserId(Long userId);


### PR DESCRIPTION
## 문제
- 알림 발송 호출이 서비스 곳곳에 직접 퍼져 있어 트랜잭션 경계가 불명확했습니다.
- 예약과 8회권 사이에 크레딧 차감/복구와 연동 취소 책임이 섞여 있었습니다.
- 관리자 답변 응답 조립과 장바구니 checkout 주입도 구현체에 직접 묶여 있었습니다.

## 핵심 설계 판단
- 알림은 `NotificationRequestedEvent`를 발행하고 `AFTER_COMMIT` 비동기 리스너에서 발송하도록 정리했습니다.
- 예약 쪽은 `PassCreditPort`, 8회권 쪽은 `BookingCancellationPort`를 통해 서로의 내부 저장 구현을 직접 알지 않도록 정리했습니다.
- 관리자 문의/Q&A 답변은 `replyAndGet`으로 저장과 응답 조립을 한 번에 처리하고, 장바구니 checkout은 `CartCheckoutUseCase`로 주입했습니다.

## 테스트
- `./gradlew --no-daemon :app:compileJava`
- `./gradlew --no-daemon :app:test --tests com.personal.happygallery.app.web.admin.AdminLoginUseCaseIT --tests com.personal.happygallery.infra.payment.FakePaymentProviderTest`
- `./gradlew --no-daemon :app:test --tests com.personal.happygallery.app.booking.BookingCancelUseCaseIT --tests com.personal.happygallery.app.booking.BookingReminderBatchUseCaseIT --tests com.personal.happygallery.app.pass.PassExpiryNotificationUseCaseIT --tests com.personal.happygallery.app.booking.RefundExecutionServiceUseCaseIT`

## 문서 반영
- README와 HANDOFF를 현재 구조와 리팩터링 기준으로 갱신했습니다.
