### PR TITLE
리팩터링: 백엔드 마스킹과 주문 생성 타입 정리

### DIFF
--- a/app/src/main/java/com/personal/happygallery/app/cart/DefaultCartCheckoutService.java
+++ b/app/src/main/java/com/personal/happygallery/app/cart/DefaultCartCheckoutService.java
@@ -13,12 +13,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
-public class CartCheckoutService implements CartCheckoutUseCase {
+public class DefaultCartCheckoutService implements CartCheckoutUseCase {
 
     private final CartUseCase cartUseCase;
     private final OrderCreationUseCase orderCreationUseCase;
 
-    public CartCheckoutService(CartUseCase cartUseCase, OrderCreationUseCase orderCreationUseCase) {
+    public DefaultCartCheckoutService(CartUseCase cartUseCase, OrderCreationUseCase orderCreationUseCase) {
         this.cartUseCase = cartUseCase;
         this.orderCreationUseCase = orderCreationUseCase;
     }

--- a/app/src/main/java/com/personal/happygallery/app/notification/NotificationService.java
+++ b/app/src/main/java/com/personal/happygallery/app/notification/NotificationService.java
@@ -104,21 +104,7 @@ public class NotificationService {
 
     void sendToGuest(Long guestId, String phone, String name,
                      NotificationEventType eventType) {
-        LocalDateTime sentAt = LocalDateTime.now(clock);
-        for (NotificationSenderPort sender : senders) {
-            try {
-                boolean success = sender.send(phone, name, eventType);
-                if (success) {
-                    save(NotificationLog.success(guestId, null, sender.channel(), eventType, sentAt));
-                    return;
-                }
-                save(NotificationLog.failed(guestId, null, sender.channel(), eventType, "발송 실패", sentAt));
-            } catch (Exception e) {
-                log.warn("[알림] {} 발송 예외 [guestId={} event={}]", sender.channel(), guestId, eventType, e);
-                save(NotificationLog.failed(guestId, null, sender.channel(), eventType, e.getMessage(), sentAt));
-            }
-        }
-        log.error("[알림] 모든 채널 실패 [guestId={} event={}]", guestId, eventType);
+        sendNotification(guestId, null, phone, name, eventType);
     }
 
     void sendByGuestId(Long guestId, NotificationEventType eventType) {
@@ -143,21 +129,29 @@ public class NotificationService {
 
     void sendToUser(Long userId, String phone, String name,
                     NotificationEventType eventType) {
+        sendNotification(null, userId, phone, name, eventType);
+    }
+
+    private void sendNotification(Long guestId, Long userId, String phone, String name,
+                                  NotificationEventType eventType) {
         LocalDateTime sentAt = LocalDateTime.now(clock);
+        Long recipientId = guestId != null ? guestId : userId;
+        String recipientLabel = guestId != null ? "guestId" : "userId";
+
         for (NotificationSenderPort sender : senders) {
             try {
                 boolean success = sender.send(phone, name, eventType);
                 if (success) {
-                    save(NotificationLog.success(null, userId, sender.channel(), eventType, sentAt));
+                    save(NotificationLog.success(guestId, userId, sender.channel(), eventType, sentAt));
                     return;
                 }
-                save(NotificationLog.failed(null, userId, sender.channel(), eventType, "발송 실패", sentAt));
+                save(NotificationLog.failed(guestId, userId, sender.channel(), eventType, "발송 실패", sentAt));
             } catch (Exception e) {
-                log.warn("[알림] {} 발송 예외 [userId={} event={}]", sender.channel(), userId, eventType, e);
-                save(NotificationLog.failed(null, userId, sender.channel(), eventType, e.getMessage(), sentAt));
+                log.warn("[알림] {} 발송 예외 [{}={} event={}]", sender.channel(), recipientLabel, recipientId, eventType, e);
+                save(NotificationLog.failed(guestId, userId, sender.channel(), eventType, e.getMessage(), sentAt));
             }
         }
-        log.error("[알림] 모든 채널 실패 [userId={} event={}]", userId, eventType);
+        log.error("[알림] 모든 채널 실패 [{}={} event={}]", recipientLabel, recipientId, eventType);
     }
 
     private void save(NotificationLog entry) {

--- a/app/src/main/java/com/personal/happygallery/app/order/DefaultOrderCreationService.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/DefaultOrderCreationService.java
@@ -33,7 +33,7 @@ public class DefaultOrderCreationService implements OrderCreationUseCase {
     /**
      * 휴대폰 인증 기반 주문 생성.
      */
-    public OrderService.OrderCreationResult createOrderByPhone(CreateOrderByPhoneCommand command) {
+    public OrderCreationResult createOrderByPhone(CreateOrderByPhoneCommand command) {
         Guest guest = verifiedGuestResolver.resolveVerifiedGuest(
                 command.phone(),
                 command.verificationCode(),

--- a/app/src/main/java/com/personal/happygallery/app/order/OrderService.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/OrderService.java
@@ -1,5 +1,6 @@
 package com.personal.happygallery.app.order;
 
+import com.personal.happygallery.app.order.port.in.OrderCreationUseCase.OrderCreationResult;
 import com.personal.happygallery.app.order.port.out.OrderItemPort;
 import com.personal.happygallery.app.order.port.out.OrderStorePort;
 import com.personal.happygallery.domain.notification.NotificationEventType;
@@ -59,8 +60,6 @@ public class OrderService {
      * @param items   주문 상품 목록
      * @return 생성된 주문
      */
-    public record OrderCreationResult(Order order, String rawAccessToken) {}
-
     public OrderCreationResult createPaidOrder(Long guestId, List<OrderItemRequest> items) {
         LocalDateTime paidAt = LocalDateTime.now(clock);
         long totalAmount = items.stream().mapToLong(i -> (long) i.qty() * i.unitPrice()).sum();

--- a/app/src/main/java/com/personal/happygallery/app/order/port/in/OrderCreationUseCase.java
+++ b/app/src/main/java/com/personal/happygallery/app/order/port/in/OrderCreationUseCase.java
@@ -1,6 +1,5 @@
 package com.personal.happygallery.app.order.port.in;
 
-import com.personal.happygallery.app.order.OrderService.OrderCreationResult;
 import com.personal.happygallery.domain.order.Order;
 import java.util.List;
 
@@ -19,6 +18,8 @@ public interface OrderCreationUseCase {
             items = List.copyOf(items);
         }
     }
+
+    record OrderCreationResult(Order order, String rawAccessToken) {}
 
     OrderCreationResult createOrderByPhone(CreateOrderByPhoneCommand command);
 

--- a/app/src/main/java/com/personal/happygallery/app/web/MaskingUtil.java
+++ b/app/src/main/java/com/personal/happygallery/app/web/MaskingUtil.java
@@ -1,0 +1,21 @@
+package com.personal.happygallery.app.web;
+
+/**
+ * 공개 응답에서 개인정보를 마스킹하는 유틸리티.
+ */
+public final class MaskingUtil {
+
+    private MaskingUtil() {}
+
+    /** "홍길동" → "홍**" */
+    public static String maskName(String name) {
+        if (name == null || name.length() <= 1) return "*";
+        return name.charAt(0) + "*".repeat(name.length() - 1);
+    }
+
+    /** "010-1234-5678" → "010****5678" (가운데 4자리 마스킹) */
+    public static String maskPhoneMiddle(String phone) {
+        if (phone == null || phone.length() < 7) return phone;
+        return phone.substring(0, 3) + "****" + phone.substring(phone.length() - 4);
+    }
+}

--- a/app/src/main/java/com/personal/happygallery/app/web/booking/dto/BookingDetailResponse.java
+++ b/app/src/main/java/com/personal/happygallery/app/web/booking/dto/BookingDetailResponse.java
@@ -1,5 +1,7 @@
 package com.personal.happygallery.app.web.booking.dto;
 
+import static com.personal.happygallery.app.web.MaskingUtil.maskPhoneMiddle;
+
 import com.personal.happygallery.domain.booking.Booking;
 import java.time.LocalDateTime;
 
@@ -18,7 +20,7 @@ public record BookingDetailResponse(
 ) {
     public static BookingDetailResponse from(Booking booking) {
         String rawPhone = booking.getGuest().getPhone();
-        String maskedPhone = maskPhone(rawPhone);
+        String maskedPhone = maskPhoneMiddle(rawPhone);
         return new BookingDetailResponse(
                 booking.getId(),
                 "BK-%08d".formatted(booking.getId()),
@@ -32,11 +34,5 @@ public record BookingDetailResponse(
                 booking.getGuest().getName(),
                 maskedPhone
         );
-    }
-
-    /** 010-1234-5678 → 010****5678 (가운데 4자리 마스킹) */
-    private static String maskPhone(String phone) {
-        if (phone == null || phone.length() < 7) return phone;
-        return phone.substring(0, 3) + "****" + phone.substring(phone.length() - 4);
     }
 }

--- a/app/src/main/java/com/personal/happygallery/app/web/product/dto/ProductQnaDetail.java
+++ b/app/src/main/java/com/personal/happygallery/app/web/product/dto/ProductQnaDetail.java
@@ -1,5 +1,7 @@
 package com.personal.happygallery.app.web.product.dto;
 
+import static com.personal.happygallery.app.web.MaskingUtil.maskName;
+
 import com.personal.happygallery.app.qna.port.in.ProductQnaUseCase.QnaWithAuthor;
 import com.personal.happygallery.domain.qna.ProductQna;
 import java.time.LocalDateTime;
@@ -15,10 +17,5 @@ public record ProductQnaDetail(
                 q.getId(), q.getProductId(), q.getTitle(), q.getContent(),
                 q.getReplyContent(), q.getRepliedAt(),
                 q.isSecret(), maskName(qa.authorName()), q.getCreatedAt());
-    }
-
-    private static String maskName(String name) {
-        if (name == null || name.length() <= 1) return "*";
-        return name.charAt(0) + "*".repeat(name.length() - 1);
     }
 }

--- a/app/src/main/java/com/personal/happygallery/app/web/product/dto/ProductQnaListItem.java
+++ b/app/src/main/java/com/personal/happygallery/app/web/product/dto/ProductQnaListItem.java
@@ -1,5 +1,7 @@
 package com.personal.happygallery.app.web.product.dto;
 
+import static com.personal.happygallery.app.web.MaskingUtil.maskName;
+
 import com.personal.happygallery.app.qna.port.in.ProductQnaUseCase.QnaWithAuthor;
 import com.personal.happygallery.domain.qna.ProductQna;
 import java.time.LocalDateTime;
@@ -14,10 +16,5 @@ public record ProductQnaListItem(
         return new ProductQnaListItem(
                 q.getId(), displayTitle, maskName(qa.authorName()),
                 q.isSecret(), q.hasReply(), q.getCreatedAt());
-    }
-
-    private static String maskName(String name) {
-        if (name == null || name.length() <= 1) return "*";
-        return name.charAt(0) + "*".repeat(name.length() - 1);
     }
 }


### PR DESCRIPTION
## 문제
- 장바구니 checkout 구현체 이름과 주문 생성 결과 타입 위치가 구현 중심으로 남아 있었습니다.
- 공개 응답의 마스킹 로직과 알림 로그 기록 로직에 중복이 있었습니다.

## 핵심 변경
- CartCheckoutService를 DefaultCartCheckoutService로 정리하고, OrderCreationResult를 OrderCreationUseCase 안으로 옮겨 타입 소유 위치를 맞췄습니다.
- MaskingUtil을 추가해 공개 응답 DTO의 이름/전화번호 마스킹 로직을 공통화했습니다.
- NotificationService의 guest/user 발송 로그 저장 경로를 sendNotification으로 합쳐 중복을 줄였습니다.

## 테스트
- ./gradlew --no-daemon :app:compileJava

## 제외 범위
- 프론트 변경은 커밋하지 않았고 이번 PR에도 포함하지 않았습니다.
